### PR TITLE
ci: check jobs use kebab names (ci-build, checks-<surface>-<tool>)

### DIFF
--- a/.github/workflows/checks-js.yml
+++ b/.github/workflows/checks-js.yml
@@ -1,8 +1,8 @@
 name: Checks JS
 
 # node --check syntax validation of every JS file in the repo (project +
-# vendored) — runs once on main (or dispatch) when any .js changes, anywhere.
-# Extension-wide so NEW js files in new locations are never missed.
+# vendored) — runs on pull requests (or dispatch) when any .js changes,
+# anywhere. Extension-wide so NEW js files in new locations are never missed.
 on:
   pull_request:
     branches: [main]
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  node-check:
-    name: Checks JS
+  checks-js-node-check:
+    name: checks-js-node-check
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-python.yml
+++ b/.github/workflows/checks-python.yml
@@ -1,8 +1,8 @@
 name: Checks Python
 
-# Ruff lint on every python file in the repo — runs once on main (or dispatch)
-# when any .py changes, anywhere. Extension-wide so NEW python files in new
-# locations are never missed.
+# Ruff lint on every python file in the repo — runs on pull requests (or
+# dispatch) when any .py changes, anywhere. Extension-wide so NEW python files
+# in new locations are never missed.
 on:
   pull_request:
     branches: [main]
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  ruff:
-    name: Checks Python
+  checks-python-ruff:
+    name: checks-python-ruff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-shell.yml
+++ b/.github/workflows/checks-shell.yml
@@ -1,8 +1,8 @@
 name: Checks Shell
 
 # Shellcheck on every shell script in the repo (scripts/*.sh + .githooks/*) —
-# runs once on main (or dispatch) when any .sh changes, anywhere. Extension-wide
-# so NEW shell scripts in new locations are never missed.
+# runs on pull requests (or dispatch) when any .sh changes, anywhere.
+# Extension-wide so NEW shell scripts in new locations are never missed.
 on:
   pull_request:
     branches: [main]
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  shellcheck:
-    name: Checks Shell
+  checks-shell-shellcheck:
+    name: checks-shell-shellcheck
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-terraform.yml
+++ b/.github/workflows/checks-terraform.yml
@@ -1,8 +1,9 @@
 name: Checks Terraform
 
 # STATIC checks only (fmt / validate / tflint / checkov) — no AWS credentials
-# involved. Runs on pull requests + main (or dispatch) when terraform/ changes.
-# Single job so the check name matches the workflow name. This is NOT the
+# involved. Runs on pull requests (or dispatch) when terraform/ changes. One
+# job per stage so branch protection can gate each check independently
+# (checks-terraform-fmt / -validate / -lint / -security). This is NOT the
 # deploy pipeline: terraform.yml plans/applies the real stack (staging
 # auto-apply on main, prod plan-only on v* tags).
 on:
@@ -20,19 +21,27 @@ permissions:
   contents: read
 
 jobs:
-  checks-terraform:
-    name: Checks Terraform
+  checks-terraform-fmt:
+    name: checks-terraform-fmt
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
-
       - name: terraform fmt -check
         run: terraform fmt -check -recursive -diff terraform/
 
+  checks-terraform-validate:
+    name: checks-terraform-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
       # All three roots have committed .terraform.lock.hcl files — readonly
       # detects drift (modules/metrics got its lockfile 2026-08-28 so the
       # local check-compose validate can run on a read-only mount).
@@ -41,19 +50,23 @@ jobs:
         run: |
           terraform init -backend=false -input=false -lockfile=readonly
           terraform validate -no-color
-
       - name: terraform init + validate (terraform/ci)
         working-directory: terraform/ci
         run: |
           terraform init -backend=false -input=false -lockfile=readonly
           terraform validate -no-color
-
       - name: terraform init + validate (terraform/modules/metrics)
         working-directory: terraform/modules/metrics
         run: |
           terraform init -backend=false -input=false -lockfile=readonly
           terraform validate -no-color
 
+  checks-terraform-lint:
+    name: checks-terraform-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
       - uses: terraform-linters/setup-tflint@v6
         with:
           tflint_version: latest
@@ -68,6 +81,12 @@ jobs:
         working-directory: terraform/ci
         run: tflint --format compact --config "$GITHUB_WORKSPACE/.tflint.hcl"
 
+  checks-terraform-security:
+    name: checks-terraform-security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
       - name: Checkov
         uses: bridgecrewio/checkov-action@v12
         with:

--- a/.github/workflows/checks-yml.yml
+++ b/.github/workflows/checks-yml.yml
@@ -1,9 +1,10 @@
 name: Checks YAML
 
 # actionlint on the GitHub Actions workflows + a YAML syntax parse of every
-# yml/yaml in the repo. Runs on pull requests + main (or dispatch) when any
-# yml/yaml changes, anywhere (extension-wide — new yaml files are never
-# missed). Single job so the check name matches the workflow name.
+# yml/yaml in the repo. Runs on pull requests (or dispatch) when any yml/yaml
+# changes, anywhere (extension-wide — new yaml files are never missed). One job
+# per stage so branch protection can gate each check independently
+# (checks-yaml-syntax / checks-yaml-actionlint).
 on:
   pull_request:
     branches: [main]
@@ -16,13 +17,12 @@ permissions:
   contents: read
 
 jobs:
-  checks-yaml:
-    name: Checks YAML
+  checks-yaml-syntax:
+    name: checks-yaml-syntax
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-
       - name: Parse YAML (Ruby's built-in psych — no installs)
         run: |
           find . -path './site' -prune -o -path './.git' -prune -o -type f \( -name '*.yml' -o -name '*.yaml' \) -print 2>/dev/null | while IFS= read -r f; do
@@ -30,6 +30,12 @@ jobs:
             echo "ok: $f"
           done
 
+  checks-yaml-actionlint:
+    name: checks-yaml-actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
       # v2 required: v1 is a composite wrapping github-script@v7 internally,
       # which crashes on Node-24 runners (ERR_PACKAGE_PATH_NOT_EXPORTED).
       - uses: raven-actions/actionlint@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: CI
+  ci-build:
+    name: ci-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,16 +35,23 @@ requests.
 
 ## Checks
 
-Each surface is linted by its own workflow (all run on PRs and on `main`):
+Each surface is linted by its own workflow; checks run on PRs (path-filtered
+— only the workflows matching your changed files run) and via manual dispatch.
+**Branch protection requires checks by job name** (not workflow name) — the
+names below are what you'll see on PRs:
 
-| Workflow | Covers |
+| Required check | Covers |
 | --- | --- |
-| `CI` | strict `mkdocs build`, pip-audit, internal link + translation checks |
-| `checks-python` | `ruff` on `terraform/lambda/**` + `scripts/*.py` |
-| `checks-shell` | `shellcheck` on `scripts/*.sh` |
-| `checks-js` | JS lint on `docs/**/*.js` |
-| `checks-terraform` | `terraform fmt`/`validate`, tflint, checkov |
-| `checks-yml` | actionlint on workflows + YAML parsing |
+| `ci-build` | strict `mkdocs build`, pip-audit, internal link + translation checks |
+| `checks-python-ruff` | `ruff` on `terraform/lambda/**` + `scripts/*.py` |
+| `checks-shell-shellcheck` | `shellcheck` on `scripts/*.sh` |
+| `checks-js-node-check` | JS syntax check on `docs/**/*.js` |
+| `checks-terraform-fmt` | `terraform fmt -check` |
+| `checks-terraform-validate` | `terraform validate` (all three roots) |
+| `checks-terraform-lint` | TFLint |
+| `checks-terraform-security` | Checkov security scan |
+| `checks-yaml-syntax` | YAML parse of every yml/yaml |
+| `checks-yaml-actionlint` | actionlint on workflows + compose/mkdocs YAML |
 
 ## Translations
 


### PR DESCRIPTION
Branch protection requires checks by job name, so each job's key and name: are set identically to make the reported check unambiguous:

- ci.yml: build -> ci-build
- checks-python.yml: ruff -> checks-python-ruff
- checks-shell.yml: shellcheck -> checks-shell-shellcheck
- checks-js.yml: node-check -> checks-js-node-check
- checks-terraform.yml: one job -> four per-stage jobs (checks-terraform-fmt / -validate / -lint / -security)
- checks-yml.yml: one job -> two per-stage jobs (checks-yaml-syntax / checks-yaml-actionlint)

Local check-compose.yaml already mirrored the per-stage split. Checks now run on pull_request only (PR-only triggers from oss/hygiene), so the 'once on main' comments were dropped. CONTRIBUTING checks table lists the required check names.

## What does this PR do?

<!-- Brief description of the change and why. -->

## Related issue(s)

<!-- Fixes #123 / Closes #456 — or "n/a". -->

## Type of change

- [ ] Content (page / translation / asset)
- [ ] Feature
- [ ] Fix
- [ ] Tooling / CI
- [ ] Docs

## Checklist

- [ ] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only)
- [ ] Page-scoped changes — no other pages affected (or blast radius checked)
- [ ] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change

## Screenshots / verification

<!-- Optional: what did you verify? -->
