### PR TITLE
docs: add Chore / CI task issue template + document the 7-part format…

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,33 @@
+name: Chore / CI task
+description: Tooling, CI/CD, refactors, docs — anything that doesn't change user-facing site content
+title: ""
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: A clear and concise description of the problem or gap.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternatives you've thought of.
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      description: How does this touch the site?
+      options:
+        - label: Page/content change (one page, with es/zh if content)
+        - label: Global file (extra.css / main.html / mkdocs.yml / javascripts)
+        - label: Infra / tooling (workflows, terraform, scripts)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,25 @@ names below are what you'll see on PRs:
 | `checks-yaml-syntax` | YAML parse of every yml/yaml |
 | `checks-yaml-actionlint` | actionlint on workflows + compose/mkdocs YAML |
 
+## Issues
+
+Issues follow a fixed structure (enforced by the issue templates — **Feature request**
+for site content/features, **Chore / CI task** for tooling/CI/CD/docs):
+
+1. **Title** — conventional prefix (`feat:` / `fix:` / `docs:` / `ci:`).
+2. **What problem does this solve?*** — required.
+3. **Proposed solution** — required.
+4. **Alternatives considered**.
+5. **Scope** — how does this touch the site?
+   - Page/content change (one page, with es/zh if content)
+   - Global file (`extra.css` / `main.html` / `mkdocs.yml` / `javascripts`)
+   - Infra / tooling (workflows, terraform, scripts)
+6. **Label** — repo uses the GitHub defaults (`enhancement` for features, `bug`, `documentation`, …).
+7. **Milestone** — set by the maintainer via the sidebar (every issue has it; not a form field).
+
+The assignee is the maintainer doing the work (self-assigned); PRs reference the
+issue (`Closes #N`).
+
 ## Translations
 
 Content is maintained **English first** — open the English change, then add the


### PR DESCRIPTION
… in CONTRIBUTING

- chore.yml: tooling/CI/docs template — same body as Feature request (problem* / proposed solution / alternatives / scope) but no title prefix and no default label.
- Milestone stays sidebar-only (every issue has it) — not a form field.
- CONTRIBUTING: Issues section documents the 7-part format and the assignee convention (maintainer self-assigns; PRs reference Closes #N).

## What does this PR do?

<!-- Brief description of the change and why. -->

## Related issue(s)

<!-- Fixes #123 / Closes #456 — or "n/a". -->

## Type of change

- [ ] Content (page / translation / asset)
- [ ] Feature
- [ ] Fix
- [ ] Tooling / CI
- [ ] Docs

## Checklist

- [ ] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only)
- [ ] Page-scoped changes — no other pages affected (or blast radius checked)
- [ ] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change

## Screenshots / verification

<!-- Optional: what did you verify? -->
