### PR TITLE
ci: skip-model for surface checks (job-level gates, no paths: filters)

### DIFF
--- a/.github/workflows/checks-js.yml
+++ b/.github/workflows/checks-js.yml
@@ -1,21 +1,37 @@
 name: Checks JS
 
 # node --check syntax validation of every JS file in the repo (project +
-# vendored) — runs on pull requests (or dispatch) when any .js changes,
-# anywhere. Extension-wide so NEW js files in new locations are never missed.
+# vendored). Runs on pull requests (or dispatch); a job-level gate
+# (dorny/paths-filter) makes the check SKIP — reporting success — when the PR
+# touches no JS files, so requiring this check never blocks unrelated PRs.
+# Extension-wide so NEW js files in new locations are never missed.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.js"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - '**/*.js'
+
   checks-js-node-check:
     name: checks-js-node-check
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-python.yml
+++ b/.github/workflows/checks-python.yml
@@ -1,21 +1,37 @@
 name: Checks Python
 
-# Ruff lint on every python file in the repo — runs on pull requests (or
-# dispatch) when any .py changes, anywhere. Extension-wide so NEW python files
-# in new locations are never missed.
+# Ruff lint on every python file in the repo. Runs on pull requests (or
+# dispatch); a job-level gate (dorny/paths-filter) makes the check SKIP —
+# reporting success — when the PR touches no python files, so requiring this
+# check never blocks unrelated PRs (GitHub treats skipped jobs as success).
+# Extension-wide so NEW python files in new locations are never missed.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.py"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - '**/*.py'
+
   checks-python-ruff:
     name: checks-python-ruff
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-shell.yml
+++ b/.github/workflows/checks-shell.yml
@@ -1,21 +1,38 @@
 name: Checks Shell
 
-# Shellcheck on every shell script in the repo (scripts/*.sh + .githooks/*) —
-# runs on pull requests (or dispatch) when any .sh changes, anywhere.
-# Extension-wide so NEW shell scripts in new locations are never missed.
+# Shellcheck on every shell script in the repo (scripts/*.sh + .githooks/*).
+# Runs on pull requests (or dispatch); a job-level gate (dorny/paths-filter)
+# makes the check SKIP — reporting success — when the PR touches no shell
+# files, so requiring this check never blocks unrelated PRs. Extension-wide so
+# NEW shell scripts in new locations are never missed.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.sh"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - '**/*.sh'
+              - '.githooks/**'
+
   checks-shell-shellcheck:
     name: checks-shell-shellcheck
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-terraform.yml
+++ b/.github/workflows/checks-terraform.yml
@@ -1,17 +1,16 @@
 name: Checks Terraform
 
 # STATIC checks only (fmt / validate / tflint / checkov) — no AWS credentials
-# involved. Runs on pull requests (or dispatch) when terraform/ changes. One
-# job per stage so branch protection can gate each check independently
+# involved. Runs on pull requests (or dispatch); a job-level gate
+# (dorny/paths-filter) makes the checks SKIP — reporting success — when the PR
+# touches no terraform files, so requiring them never blocks unrelated PRs.
+# One job per stage so branch protection can gate each check independently
 # (checks-terraform-fmt / -validate / -lint / -security). This is NOT the
 # deploy pipeline: terraform.yml plans/applies the real stack (staging
 # auto-apply on main, prod plan-only on v* tags).
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "terraform/**"
-      - ".tflint.hcl"
   workflow_dispatch: {}
 
 env:
@@ -21,8 +20,25 @@ permissions:
   contents: read
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - 'terraform/**'
+              - '.tflint.hcl'
+
   checks-terraform-fmt:
     name: checks-terraform-fmt
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,6 +51,8 @@ jobs:
 
   checks-terraform-validate:
     name: checks-terraform-validate
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -63,6 +81,8 @@ jobs:
 
   checks-terraform-lint:
     name: checks-terraform-lint
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -83,6 +103,8 @@ jobs:
 
   checks-terraform-security:
     name: checks-terraform-security
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/checks-yml.yml
+++ b/.github/workflows/checks-yml.yml
@@ -1,24 +1,40 @@
 name: Checks YAML
 
 # actionlint on the GitHub Actions workflows + a YAML syntax parse of every
-# yml/yaml in the repo. Runs on pull requests (or dispatch) when any yml/yaml
-# changes, anywhere (extension-wide — new yaml files are never missed). One job
-# per stage so branch protection can gate each check independently
-# (checks-yaml-syntax / checks-yaml-actionlint).
+# yml/yaml in the repo. Runs on pull requests (or dispatch); a job-level gate
+# (dorny/paths-filter) makes the checks SKIP — reporting success — when the PR
+# touches no yml/yaml files, so requiring them never blocks unrelated PRs.
+# Extension-wide — new yaml files are never missed, and workflow-file edits
+# trigger actionlint (self-validation). One job per stage so branch protection
+# can gate each check independently (checks-yaml-syntax / checks-yaml-actionlint).
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.yml"
-      - "**/*.yaml"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - '**/*.yml'
+              - '**/*.yaml'
+
   checks-yaml-syntax:
     name: checks-yaml-syntax
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -32,6 +48,8 @@ jobs:
 
   checks-yaml-actionlint:
     name: checks-yaml-actionlint
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ requests.
 
 ## Checks
 
-Each surface is linted by its own workflow; checks run on PRs (path-filtered
-— only the workflows matching your changed files run) and via manual dispatch.
+Each surface is linted by its own workflow; checks run on PRs and via manual dispatch.
+A surface check whose files aren't touched **skips and reports success** (GitHub treats
+skipped required checks as success), so requiring all checks never blocks unrelated PRs.
 **Branch protection requires checks by job name** (not workflow name) — the
 names below are what you'll see on PRs:
 

--- a/README.md
+++ b/README.md
@@ -47,18 +47,20 @@ Workflow files follow `{task}-{env|language|resource}` naming (e.g. `deploy-stag
   check, CSS sanity check) with the per-environment `site_url` (tags → prod, main → staging); uploads the built `site/` as an
   artifact (7-day retention).
 - **Terraform checks** (`.github/workflows/checks-terraform.yml`) — static checks on the
-  terraform code (once per `main` push when `terraform/**` changes, or manual dispatch):
+  terraform code (on pull requests, or manual dispatch — the stage checks skip, green, when
+  `terraform/**` isn't touched):
   `terraform fmt -check`, `validate`
   (all three roots: `terraform/`, `terraform/ci/`, `modules/metrics`), TFLint, and a Checkov
   security scan (informational for now). No AWS credentials — this complements (does not
   replace) the `terraform.yml` plan/apply pipeline.
 - **Per-surface checks** (`.github/workflows/checks-{shell,python,js,terraform,yml}.yml`) —
-  one workflow per surface, each running once per `main` push (or manual dispatch) when the files
-  it checks change: `shellcheck` on `scripts/*.sh`, `ruff` on `terraform/lambda/**` + `scripts/*.py`,
-  `node --check` on `docs/**/*.js` (project + vendored), and `actionlint` on
-  `.github/**` YAML + `mkdocs.yml`/`compose.yaml`. Grouped by surface (Terraform stays its own
-  file) so a change to one surface only runs that surface's checks — a checks file's own
-  change does not re-trigger it (workflow files are linted by `checks-yml`).
+  one workflow per surface, running on pull requests (or manual dispatch) with a job-level
+  relevance gate (`dorny/paths-filter`): when the PR touches none of the surface's files the
+  check **skips and reports success** — GitHub treats skipped jobs as success — so requiring all
+  checks never blocks unrelated PRs. Covers: `shellcheck` on `scripts/*.sh` + `.githooks/**`,
+  `ruff` on `**/*.py`, `node --check` on `**/*.js` (project + vendored), actionlint + YAML parse
+  on `**/*.yml`/`**/*.yaml` (workflow-file edits self-validate), and the terraform stage checks
+  on `terraform/**`.
 - **Local checks** (`check-compose.yaml`) — the same checks run locally as stage 1, one compose
   service per check (`podman-compose -f check-compose.yaml run --rm <shell|python|yaml|yaml-syntax|js>`),
   mirroring the GitHub workflows exactly (same commands + tool images). **Changed-files-only:**


### PR DESCRIPTION
Replace the on.pull_request paths: filters with job-level relevance gates: each checks-* workflow adds a detect job (dorny/paths-filter); when the PR touches none of the surface's files the check jobs SKIP. GitHub treats a skipped required check as success, so requiring all 10 checks can no longer leave unrelated PRs stuck at 'Expected — Waiting'.

- The 'Only require status checks for paths that changed' branch-protection option is not available in this account's UI (verified 2026-09-01).
- Bonus: workflow-file edits now trigger actionlint (self-validation).
- checks-shell gate also covers .githooks/** (matches the scan).
- README + CONTRIBUTING updated.

## What does this PR do?

<!-- Brief description of the change and why. -->

## Related issue(s)

<!-- Fixes #123 / Closes #456 — or "n/a". -->

## Type of change

- [ ] Content (page / translation / asset)
- [ ] Feature
- [ ] Fix
- [ ] Tooling / CI
- [ ] Docs

## Checklist

- [ ] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only)
- [ ] Page-scoped changes — no other pages affected (or blast radius checked)
- [ ] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change

## Screenshots / verification

<!-- Optional: what did you verify? -->
