### PR TITLE
fix: chore issue template — remove empty title (invalid front matter)

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,6 +1,5 @@
 name: Chore / CI task
 description: Tooling, CI/CD, refactors, docs — anything that doesn't change user-facing site content
-title: ""
 labels: []
 body:
   - type: textarea


### PR DESCRIPTION
GitHub issue-form validation rejects title: "" ('must be of type String and cannot be empty'). Omitting the field = no pre-filled prefix.

## What does this PR do?

<!-- Brief description of the change and why. -->

## Related issue(s)

<!-- Fixes #123 / Closes #456 — or "n/a". -->

## Type of change

- [ ] Content (page / translation / asset)
- [ ] Feature
- [ ] Fix
- [ ] Tooling / CI
- [ ] Docs

## Checklist

- [ ] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only)
- [ ] Page-scoped changes — no other pages affected (or blast radius checked)
- [ ] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change

## Screenshots / verification

<!-- Optional: what did you verify? -->
