### PR TITLE
fix: OIDC trust for env-bearing deploy jobs (environment-form sub)

### DIFF
--- a/scripts/bootstrap_aws.sh
+++ b/scripts/bootstrap_aws.sh
@@ -57,17 +57,18 @@ cd "$ROOT/terraform/ci"
 case "$ENV" in
   staging)
     REF_PATTERNS='["ref:refs/heads/main"]'
+    # Deploy jobs declare an environment, so GitHub's OIDC sub is
+    # repo:OWNER@*/REPO@*:environment:<name> (not ref-form). Allow the
+    # environment form for the env-bearing deploy jobs + keep the ref form for
+    # the no-environment manual dispatches (invalidate-cloudfront.yml,
+    # toggle-env.yml). Same trust serves deploy/invalidate/toggle roles.
+    DEPLOY_REF_PATTERNS='["ref:refs/heads/main", "environment:staging"]'
     ;;
   prod)
     REF_PATTERNS='["ref:refs/tags/v*"]'
+    DEPLOY_REF_PATTERNS='["ref:refs/heads/main", "environment:pre-prod"]'
     ;;
 esac
-
-# The DEPLOY role is assumed from deploy-{staging-s3,pre-prod-s3,prod-pages}.yml, which
-# fire via workflow_run — those runs are always on the default branch (main), even
-# when triggered by a tag's CI success. So the deploy role trusts main only;
-# the v*-tag-only intent for prod is enforced by the deploy workflows' own branch gates.
-DEPLOY_REF_PATTERNS='["ref:refs/heads/main"]'
 
 # State backend: the per-env S3 bucket THIS module creates. Each environment's
 # first run (greenfield — the bucket doesn't exist yet) applies with local


### PR DESCRIPTION
Closes #21

A job that declares an environment gets an OIDC sub of repo:OWNER@*/REPO@*:environment:<name> (GitHub docs) - not the ref form the deploy trust allowed. The 3-env model (PR #20) added environment: staging / pre-prod to the deploy jobs, which changed their sub and broke AWS assumes (Deploy: Staging S3 failing on sts:AssumeRoleWithWebIdentity).

bootstrap_aws.sh now passes per-env deploy_ref_patterns allowing BOTH forms: ref (main) for the no-environment manual dispatches (invalidate-cloudfront.yml, toggle-env.yml) + environment:staging (staging bootstrap) / environment:pre-prod (prod bootstrap) for the env-bearing deploy jobs. Same trust serves deploy/invalidate/toggle roles.

After merge: re-run scripts/bootstrap_aws.sh staging + prod, then re-run the failed Deploy: Staging S3.