### PR TITLE
chore: curated labels + template taxonomy (#26)

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -21,12 +21,25 @@ body:
     attributes:
       label: Alternatives considered
       description: Any workarounds or alternatives you've thought of.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Which surface does this touch? Drives the label — the issue and its PR carry matching labels.
+      options:
+        - CI / tooling
+        - Infra — Terraform / AWS
+        - Security
+        - Governance — process / rules / templates
+        - Docs
+        - Dependencies
   - type: checkboxes
     id: scope
     attributes:
       label: Scope
-      description: How does this touch the site?
+      description: How does this touch the site or repo?
       options:
         - label: Page/content change (one page, with es/zh if content)
         - label: Global file (extra.css / main.html / mkdocs.yml / javascripts)
         - label: Infra / tooling (workflows, terraform, scripts)
+        - label: Repo-level — docs / governance / process (no site or infra touch)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,8 +26,9 @@ body:
     id: scope
     attributes:
       label: Scope
-      description: How does this touch the site?
+      description: How does this touch the site or repo?
       options:
         - label: Page/content change (one page, with es/zh if content)
         - label: Global file (extra.css / main.html / mkdocs.yml / javascripts)
         - label: Infra / tooling (workflows, terraform, scripts)
+        - label: Repo-level — docs / governance / process (no site or infra touch)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,17 @@
 
 ## Type of change
 
-- [ ] Content (page / translation / asset)
-- [ ] Feature
-- [ ] Fix
-- [ ] Tooling / CI
-- [ ] Docs
+Pick the type and apply the matching label to this PR (same label as the issue):
+
+- [ ] Content (page / translation / asset) — `enhancement`
+- [ ] Feature — `enhancement`
+- [ ] Fix — `bug`
+- [ ] CI / tooling — `ci`
+- [ ] Infra (Terraform / AWS) — `infra`
+- [ ] Security — `security`
+- [ ] Governance (process / rules / templates) — `governance`
+- [ ] Docs — `documentation`
+- [ ] Dependencies — `dependencies`
 
 ## Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,34 @@ for site content/features, **Chore / CI task** for tooling/CI/CD/docs):
 2. **What problem does this solve?*** — required.
 3. **Proposed solution** — required.
 4. **Alternatives considered**.
-5. **Scope** — how does this touch the site?
+5. **Scope** — how does this touch the site or repo?
    - Page/content change (one page, with es/zh if content)
    - Global file (`extra.css` / `main.html` / `mkdocs.yml` / `javascripts`)
    - Infra / tooling (workflows, terraform, scripts)
-6. **Label** — repo uses the GitHub defaults (`enhancement` for features, `bug`, `documentation`, …).
+   - Repo-level — docs / governance / process (no site or infra touch)
+6. **Label** — the repo's label set: GitHub defaults (`enhancement` for features,
+   `bug`, `documentation`, `question`, …) plus the custom per-surface labels below.
 7. **Milestone** — set by the maintainer via the sidebar (every issue has it; not a form field).
 
 The assignee is the maintainer doing the work (self-assigned); PRs reference the
 issue (`Closes #N`).
+
+## Labels
+
+The repo keeps the GitHub defaults and adds five per-surface labels; issues and
+PRs carry **matching labels** (an issue opened as `governance` ships in a PR
+also labeled `governance`).
+
+| Label | Color | Covers |
+| --- | --- | --- |
+| `ci` | `#0e8a16` | CI/CD — workflows, checks, actions |
+| `infra` | `#d93f0b` | Infrastructure — Terraform / AWS / deploy targets |
+| `security` | `#b60205` | Security — hardening, audit, review |
+| `governance` | `#5319e7` | Repo process as code — rulesets, templates, contributing, labels |
+| `dependencies` | `#1d76db` | Dependency updates (Dependabot) |
+
+Surfaces that keep a GitHub default: content/features → `enhancement`, fixes →
+`bug`, docs → `documentation`.
 
 ## Translations
 


### PR DESCRIPTION
## What does this PR do?

Adds the curated label taxonomy and aligns the repo's templates with it:

- **Labels** (repo settings, already applied): `ci` · `infra` · `security` · `governance` · `dependencies` — on top of the GitHub defaults.
- **PR template** — "Type of change" now maps each box to its label and reminds that the PR carries the issue's label.
- **`chore.yml`** — new **Type** dropdown (CI/tooling · Infra · Security · Governance · Docs · Dependencies) so chore issues express their surface; **Scope** gains the *Repo-level — docs / governance / process (no site or infra touch)* option.
- **`feature_request.yml`** — Scope gains the same Repo-level option (identical block kept in sync).
- **`CONTRIBUTING.md`** — new **Labels** section (taxonomy with colors + matching-label rule); Issues steps 5 (Scope) and 6 (Label) updated.

## Related issue(s)

Closes #26

## Type of change

- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [x] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — repo-level only
- [x] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (repo governance, no site change)
