### PR TITLE
ci: skip staging deploy when site content is unchanged (#29)

### DIFF
--- a/.github/workflows/deploy-staging-s3.yml
+++ b/.github/workflows/deploy-staging-s3.yml
@@ -3,9 +3,12 @@ name: "Deploy: Staging S3"
 # Deploys the built site to the STAGING S3 bucket on main-push Build success.
 # gh-pages and pre-prod S3 are tag-only (deploy-prod-pages.yml /
 # deploy-pre-prod-s3.yml) — never from main.
-# Always deploys when CI succeeds on main: the artifact is built by CI with the
-# per-environment site_url/metrics_endpoint, so a successful CI run always has
-# a fresh site to sync.
+# Skips sync + invalidation when the artifact is byte-identical to the last
+# staging deploy (content-hash marker .deploy-hash in the bucket). Content,
+# not commits, is compared — so a docs-only merge or multi-commit batch that
+# produces the same site skips cleanly and staging can never go stale.
+# Missing marker = first deploy. Revision-date embeds can make the hash differ
+# across day boundaries — then it deploys as usual (never stale, best-effort).
 on:
   workflow_run:
     workflows: ["Build"]
@@ -36,8 +39,25 @@ jobs:
           role-to-assume: ${{ secrets.STAGING_DEPLOY_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Compare artifact hash with last deployed content (.deploy-hash marker)
+        id: check
+        run: |
+          HASH="$(find site -type f | sort | xargs sha256sum | sha256sum | awk '{print $1}')"
+          OLD="$(aws s3 cp "s3://${{ secrets.PROJECT }}-staging-site/.deploy-hash" - 2>/dev/null || true)"
+          if [ -n "$OLD" ] && [ "$OLD" = "$HASH" ]; then
+            echo "Site content unchanged since the last staging deploy — skipping sync + invalidation."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Site content changed (or first deploy) — deploying."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Sync site to staging S3 (bucket root — site serves at /)
-        run: aws s3 sync site/ "s3://${{ secrets.PROJECT }}-staging-site/" --delete --no-progress
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          aws s3 sync site/ "s3://${{ secrets.PROJECT }}-staging-site/" --delete --no-progress --exclude ".deploy-hash"
+          printf '%s' "${{ steps.check.outputs.hash }}" | aws s3 cp - "s3://${{ secrets.PROJECT }}-staging-site/.deploy-hash"
 
       - name: Assume edge-invalidate role (least privilege)
         uses: aws-actions/configure-aws-credentials@v6
@@ -46,6 +66,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Invalidate staging CloudFront (lookup by comment convention)
+        if: steps.check.outputs.changed == 'true'
         run: |
           ID="$(aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='${{ secrets.PROJECT }}-staging-site'].Id" --output text)"
           if [ -n "$ID" ]; then

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ flowchart LR
   syncs the artifact to the **staging S3 bucket** (`<project>-staging-site`) with the S3-only
   deploy role, then invalidates CloudFront with the edge-invalidate role (least privilege —
   `STAGING_DEPLOY_ROLE_ARN` + `STAGING_INVALIDATE_ROLE_ARN`). The `staging` environment.
+  **Content-hash skip:** sync + invalidation are skipped when the artifact is byte-identical to
+  the last staging deploy (marker `.deploy-hash` in the bucket) — content, not commits, is
+  compared, so docs-only merges skip cleanly and multi-commit batches can't leave staging stale.
 - **Deploy pre-prod s3** (`.github/workflows/deploy-pre-prod-s3.yml`) — on CI success for **`v*` tags only**:
   syncs the artifact to the **prod S3 bucket** (`<project>-prod-site`) + CloudFront
   invalidation (OIDC `PROD_DEPLOY_ROLE_ARN` + `PROD_INVALIDATE_ROLE_ARN`) — the **`pre-prod`**


### PR DESCRIPTION
## What does this PR do?

Makes the staging deploy skip work when the built site hasn't actually changed, without reintroducing the commit-based gate that was removed in 2026-09-01 (it compared `HEAD~1..HEAD` and let multi-commit batches go stale).

`.github/workflows/deploy-staging-s3.yml` now:

1. Hashes the downloaded `site/` artifact (`find | sort | sha256sum`).
2. Reads the `.deploy-hash` marker object from the staging bucket (missing → first deploy → deploy).
3. **Equal** → skips sync **and** the CloudFront invalidation (job reports success).
4. **Different** → syncs with `--exclude ".deploy-hash"` (marker survives `--delete`), writes the new hash, invalidates.

Content is compared, not commits — skip only fires when the exact bytes to sync are already live, so staging can never go stale. Revision-date embeds (git-revision plugin, day boundaries) can make the hash differ even for no-op merges — then it deploys as today (never stale, best-effort skip). Staging only; pre-prod/prod stay unconditional on `v*` tags.

`README.md` — the staging deploy bullet documents the content-hash skip.

## Related issue(s)

Closes #29

## Type of change

- [x] CI / tooling — `ci`
- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [ ] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — workflow + README only
- [x] Local checks pass for the touched surfaces (CI will verify — actionlint on the workflow)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (deploy tooling, not a site change)
