### PR TITLE
fix: staging content-hash skip — marker existence check (#31)

### DIFF
--- a/.github/workflows/deploy-staging-s3.yml
+++ b/.github/workflows/deploy-staging-s3.yml
@@ -4,11 +4,14 @@ name: "Deploy: Staging S3"
 # gh-pages and pre-prod S3 are tag-only (deploy-prod-pages.yml /
 # deploy-pre-prod-s3.yml) — never from main.
 # Skips sync + invalidation when the artifact is byte-identical to the last
-# staging deploy (content-hash marker .deploy-hash in the bucket). Content,
-# not commits, is compared — so a docs-only merge or multi-commit batch that
-# produces the same site skips cleanly and staging can never go stale.
-# Missing marker = first deploy. Revision-date embeds can make the hash differ
-# across day boundaries — then it deploys as usual (never stale, best-effort).
+# staging deploy. Marker: a zero-byte object keyed by the content hash under
+# .deploy-hash/<sha256> — written with PutObject, checked by existence with
+# ListBucket (the deploy role has no s3:GetObject, so the marker is never read).
+# Content, not commits, is compared — so a docs-only merge or multi-commit
+# batch that produces the same site skips cleanly and staging can never go
+# stale. Missing marker = first deploy. Revision-date embeds can make the hash
+# differ across day boundaries — then it deploys as usual (never stale,
+# best-effort).
 on:
   workflow_run:
     workflows: ["Build"]
@@ -43,8 +46,9 @@ jobs:
         id: check
         run: |
           HASH="$(find site -type f | sort | xargs sha256sum | sha256sum | awk '{print $1}')"
-          OLD="$(aws s3 cp "s3://${{ secrets.PROJECT }}-staging-site/.deploy-hash" - 2>/dev/null || true)"
-          if [ -n "$OLD" ] && [ "$OLD" = "$HASH" ]; then
+          # Existence check only (ListBucket) — the deploy role has no s3:GetObject,
+          # so the marker is a zero-byte object keyed by the content hash.
+          if aws s3 ls "s3://${{ secrets.PROJECT }}-staging-site/.deploy-hash/$HASH" 2>/dev/null | grep -q .; then
             echo "Site content unchanged since the last staging deploy — skipping sync + invalidation."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -56,8 +60,8 @@ jobs:
       - name: Sync site to staging S3 (bucket root — site serves at /)
         if: steps.check.outputs.changed == 'true'
         run: |
-          aws s3 sync site/ "s3://${{ secrets.PROJECT }}-staging-site/" --delete --no-progress --exclude ".deploy-hash"
-          printf '%s' "${{ steps.check.outputs.hash }}" | aws s3 cp - "s3://${{ secrets.PROJECT }}-staging-site/.deploy-hash"
+          aws s3 sync site/ "s3://${{ secrets.PROJECT }}-staging-site/" --delete --no-progress --exclude ".deploy-hash/*"
+          aws s3api put-object --bucket "${{ secrets.PROJECT }}-staging-site" --key ".deploy-hash/${{ steps.check.outputs.hash }}"
 
       - name: Assume edge-invalidate role (least privilege)
         uses: aws-actions/configure-aws-credentials@v6

--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ flowchart LR
   deploy role, then invalidates CloudFront with the edge-invalidate role (least privilege —
   `STAGING_DEPLOY_ROLE_ARN` + `STAGING_INVALIDATE_ROLE_ARN`). The `staging` environment.
   **Content-hash skip:** sync + invalidation are skipped when the artifact is byte-identical to
-  the last staging deploy (marker `.deploy-hash` in the bucket) — content, not commits, is
-  compared, so docs-only merges skip cleanly and multi-commit batches can't leave staging stale.
+  the last staging deploy (zero-byte marker objects keyed by content hash under `.deploy-hash/`,
+  existence-checked — content, not commits, is compared), so docs-only merges skip cleanly and
+  multi-commit batches can't leave staging stale.
 - **Deploy pre-prod s3** (`.github/workflows/deploy-pre-prod-s3.yml`) — on CI success for **`v*` tags only**:
   syncs the artifact to the **prod S3 bucket** (`<project>-prod-site`) + CloudFront
   invalidation (OIDC `PROD_DEPLOY_ROLE_ARN` + `PROD_INVALIDATE_ROLE_ARN`) — the **`pre-prod`**


### PR DESCRIPTION
## What does this PR do?

Fixes the #30 content-hash skip, which never fired: the `site_sync` deploy role has **no `s3:GetObject`** (only `PutObject`/`DeleteObject`/`ListBucket`/`GetBucketLocation` — see `terraform/ci/main.tf`), so the compare step's marker *read* (`aws s3 cp … -`) was denied, swallowed by `|| true`, and every staging deploy ran.

Changes in `.github/workflows/deploy-staging-s3.yml` — same content-compare semantics, **zero new IAM**:

- Marker = zero-byte object keyed by the content hash: `.deploy-hash/<sha256>` (written via `s3api put-object` = `PutObject`, already granted).
- Check = existence via `aws s3 ls` (`ListBucket`, already granted) — the marker is never read.
- Sync excludes `.deploy-hash/*` so the prefix survives `--delete` (the stale root `.deploy-hash` object from today's runs is cleaned automatically).

`README.md` — staging bullet wording updated to the existence-checked marker scheme.

## Related issue(s)

Closes #31

## Type of change

- [x] CI / tooling — `ci`
- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [ ] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — workflow + README only
- [x] Local checks pass for the touched surfaces (CI will verify — actionlint on the workflow)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (deploy tooling, not a site change)
