### PR TITLE
docs: CI/CD docs split — slim root README, add .github/workflows/README.md (#24)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,140 @@
+# Workflows — CI/CD Implementation Reference
+
+Every workflow in `.github/workflows/` — what it does, how it's triggered, which roles and
+secrets it uses, and the gotchas. The **system view** (how a change ships) lives in the root
+[`README.md`](../README.md#ci--cd); this file is the implementation detail. The **process**
+(branching, the required-checks table, issues/labels, releases) lives in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Naming conventions
+
+- **File names** — `{task}-{env|language|resource}` (`deploy-staging-s3.yml`,
+  `checks-python.yml`, `invalidate-cloudfront.yml`); task-only names for single-purpose files
+  (`ci.yml`, `release.yml`).
+- **Display names** — quoted `{Category}: {Task}` (a colon+space is invalid unquoted YAML):
+  `Build` · `Checks: {language}` · `Deploy: {env} {target}` · `Infra: {task}`.
+- **`workflow_run` matches display names** — the deploy workflows watch `Build`; renaming a
+  display name requires updating every `workflow_run` reference.
+
+## Build — `ci.yml` (`Build`)
+
+- **Triggers:** push to `main` and `v*` tags; pull requests to `main`.
+- Runs the shared [`.github/actions/build-site`](../.github/actions/build-site) action: pip cache,
+  `mkdocs build --strict`, translation-parity check, `pip-audit` dependency audit, internal link
+  check, CSS sanity check — with the per-environment `site_url` (tags → prod, main → staging)
+  and `METRICS_ENDPOINT`.
+- Uploads the built `site/` as an artifact (7-day retention).
+
+## Checks — `checks-{shell,python,js,terraform,yml}.yml`
+
+- **Triggers:** pull requests + manual dispatch, with a job-level **relevance gate**
+  (`dorny/paths-filter`): when a PR touches none of the surface's files the check **skips and
+  reports success** — GitHub treats skipped jobs as success, so requiring all checks never
+  blocks unrelated PRs.
+- **Surfaces:** `shellcheck` on every `*.sh` (repo-wide, excluding `site/`) + `.githooks/**` ·
+  `ruff` on `**/*.py` ·
+  `node --check` on `**/*.js` (project + vendored) · actionlint + YAML parse on `**/*.yml`/`**/*.yaml`
+  workflow-file edits self-validate) · terraform stages on `terraform/**` + `.tflint.hcl`
+  (`fmt -check`,
+  `validate` on all three roots, TFLint, Checkov — informational, no AWS credentials).
+- **Required checks are the job names** — see the table in `CONTRIBUTING.md` (the `main`
+  ruleset enforces them).
+- **Local parity:** `check-compose.yaml` mirrors the workflows exactly (one service per check,
+  identical commands + tool images); `scripts/check_changed.sh` runs changed-files-only
+  (pre-commit friendly: `git config core.hooksPath .githooks`). The GitHub workflows remain the
+  authoritative gate.
+
+## Deploy — `workflow_run` on Build success
+
+The two S3 deploys share the same shape: download the artifact (`run-id` of the triggering
+Build), assume the per-environment **deploy role** (OIDC), `aws s3 sync` to the bucket root,
+then assume the **invalidate role** for an inline `/*` invalidation (lookup by the
+`<project>-<env>-site` comment convention; skip when the distro is absent). The Pages deploy
+never touches AWS (see below).
+
+| Workflow | Runs on | Environment | Target | Gate |
+| --- | --- | --- | --- | --- |
+| `deploy-staging-s3.yml` | Build success on `main` | `staging` (auto, ungated) | `<project>-staging-site` (S3 + CloudFront) | content-hash skip (below) |
+| `deploy-pre-prod-s3.yml` | Build success on `v*` tags | `pre-prod` | `<project>-prod-site` (S3 + CloudFront) — AWS mirror | tag only |
+| `deploy-prod-pages.yml` | Build success on `v*` tags | `prod` (required reviewer) | GitHub Pages (canonical) | tag only + approval |
+
+- **Least privilege:** the Pages job uses the official Pages actions
+  (`configure-pages` → `upload-pages-artifact` → `deploy-pages`) with `pages: write` +
+  `id-token: write` and **no `contents: write`** (`contents: read` + `actions: read` cover the
+  artifact download); a `concurrency: group: pages` guard serializes deploys. **Requires** the
+  repo Pages setting: source = **GitHub Actions** (flip right before the next `v*` deploy).
+- **Secrets** stay repo-level with per-environment prefixes (env-scoped secrets are a future idea).
+
+### Content-hash skip (staging)
+
+Deploys on `main` skip sync + invalidation when the artifact is **byte-identical** to the last
+staging deploy. Marker: a zero-byte object keyed by a SHA-256 of the site content under
+`.deploy-hash/<hash>`, existence-checked with `s3 ls` — the deploy role deliberately has **no
+`s3:GetObject`**, so the marker is written (`s3api put-object`) and listed, never read. The sync
+excludes `.deploy-hash/*` so the marker survives `--delete`.
+
+- **Why content, not commits:** the old commit-diff gate (`HEAD~1..HEAD`) let multi-commit
+  batches go stale; content comparison can't — a skip only happens when the exact bytes to sync
+  are already live.
+- **Gotcha:** `aws s3 sync` compares size + mtime — freshly extracted artifacts always
+  re-upload; the hash skip is what prevents it.
+- **Edge case:** git-revision-date embeds can change the hash at day boundaries — then it
+  deploys as usual (never stale, best-effort).
+
+## Release — `release.yml`
+
+- **Triggers:** `v*` tags or manual dispatch. Packages `site.zip`, generates a CycloneDX SBOM
+  (`sbom.cdx.json`) from `requirements.txt`, and creates/refreshes a GitHub Release with notes
+  from `CHANGELOG.md`.
+- Releases do **not** drive deploys (tags do) — they publish the SBOM, artifact, and notes.
+
+## Infra — `terraform.yml` + operational extras
+
+- **`terraform.yml`** — plans on any change to `terraform/**`: `main` → staging (auto-apply),
+  `v*` tags → prod (plan only — apply stays manual via `workflow_dispatch`). Deep docs:
+  [`terraform/README.md`](../terraform/README.md).
+- **`toggle-env.yml`** + `scripts/toggle_cloudfront.sh` — manual dispatch: disable/enable
+  **staging** CloudFront distributions (component `site`|`metrics` × action `disable`|`enable`)
+  by flipping `Enabled` in place (no terraform apply, nothing deleted). **Staging only by
+  design** — prod has no toggle role. Caveat: the flag lives outside terraform state, so the
+  next apply restores `enabled=true`. Uses the staging edge-toggle role (per-env secret).
+- **`invalidate-cloudfront.yml`** + `scripts/invalidate_cloudfront.sh <staging|prod> [paths]` —
+  manual edge purges for out-of-band content changes (the reference implementation for the
+  inline deploy invalidation):
+
+  ```sh
+  scripts/invalidate_cloudfront.sh staging            # full invalidation (/*)
+  scripts/invalidate_cloudfront.sh prod "/about/ /metrics/"   # specific paths
+  ```
+
+## Auth model
+
+```mermaid
+flowchart LR
+    subgraph GHA[GitHub Actions]
+        BR[Build · checks · release] -->|auto-scoped GITHUB_TOKEN<br/>release elevates to contents: write| API[GitHub API]
+        DT[Deploy · terraform.yml] -->|OIDC — no long-lived keys| AWS[AWS]
+    end
+    AWS --> JR[per-environment, per-job roles<br/>terraform · deploy · invalidate · toggle]
+    JR --> RES[site + metrics stacks]
+```
+
+Build/checks/release talk to the GitHub API with the auto-scoped `GITHUB_TOKEN` (Release
+elevates it to `contents: write` to create the Release). Deploys and Terraform assume **AWS
+roles via OIDC** — one least-privilege role per job per environment; the only key-based step is
+the out-of-band `terraform/ci` bootstrap, run as an AWS user.
+
+The per-environment role ARNs and deployment values live as **repo secrets** (Settings → Secrets
+and variables → Actions), referenced by name from the workflows. Names follow a fixed pattern
+(`ENV` ∈ `STAGING` / `PROD`):
+
+| Pattern | Purpose |
+| --- | --- |
+| `{ENV}_DEPLOY_ROLE_ARN` · `{ENV}_INVALIDATE_ROLE_ARN` | S3 sync + edge purge roles |
+| `{ENV}_TERRAFORM_ROLE_ARN` | plan/apply role |
+| `{ENV}_TOGGLE_ROLE_ARN` | edge on/off flip (staging only) |
+| `PROJECT` · `AWS_REGION` | shared — bucket naming, region |
+| `{ENV}_ALLOWED_ORIGIN` · `{ENV}_METRICS_ENDPOINT` · `{ENV}_SITE_URL` | per-env build/run values |
+
+Terraform variables (`project`, `environment`, `aws_region`, `allowed_origin`, `tags`) are
+injected from those secrets (CI) or `local.tfvars` (local dev) — nothing is hardcoded.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ requests.
 ## Checks
 
 Each surface is linted by its own workflow; checks run on PRs and via manual dispatch.
+CI/CD implementation details (triggers, naming, roles, secrets) are documented in
+[`.github/workflows/README.md`](.github/workflows/README.md).
 A surface check whose files aren't touched **skips and reports success** (GitHub treats
 skipped required checks as success), so requiring all checks never blocks unrelated PRs.
 **Branch protection requires checks by job name** (not workflow name) — the
@@ -44,7 +46,7 @@ names below are what you'll see on PRs:
 | Required check | Covers |
 | --- | --- |
 | `ci-build` | strict `mkdocs build`, pip-audit, internal link + translation checks |
-| `checks-python-ruff` | `ruff` on `terraform/lambda/**` + `scripts/*.py` |
+| `checks-python-ruff` | `ruff` on `**/*.py` (repo-wide) |
 | `checks-shell-shellcheck` | `shellcheck` on `scripts/*.sh` |
 | `checks-js-node-check` | JS syntax check on `docs/**/*.js` |
 | `checks-terraform-fmt` | `terraform fmt -check` |
@@ -52,7 +54,7 @@ names below are what you'll see on PRs:
 | `checks-terraform-lint` | TFLint |
 | `checks-terraform-security` | Checkov security scan |
 | `checks-yaml-syntax` | YAML parse of every yml/yaml |
-| `checks-yaml-actionlint` | actionlint on workflows + compose/mkdocs YAML |
+| `checks-yaml-actionlint` | actionlint on `.github/workflows/**` |
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![My Portfolio](https://img.shields.io/github/v/release/mathewmusango/my-portfolio)](https://github.com/mathewmusango/my-portfolio/releases)
 [![License](https://img.shields.io/github/license/mathewmusango/my-portfolio)](https://github.com/mathewmusango/my-portfolio/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/mathewmusango/my-portfolio/ci.yml?branch=main)](https://github.com/mathewmusango/my-portfolio/actions)
-[![SBOM](https://img.shields.io/badge/SBOM-CycloneDX-blue.svg)](https://github.com/mathewmusango/my-portfolio/releases)
-[![AWS auth](https://img.shields.io/badge/AWS%20auth-OIDC%2C%20no%20keys-green.svg)](https://github.com/mathewmusango/my-portfolio/actions)
 
 ![Site preview](docs/assets/site-preview.png)
 *The live site — [mathewmusango.github.io/my-portfolio](https://mathewmusango.github.io/my-portfolio/)*
@@ -57,14 +55,10 @@ flowchart LR
     D3 --> PRD[prod — GitHub Pages]
 ```
 
-**Prod is gated**: the Pages deploy runs in the `prod` GitHub environment behind a required
-reviewer — `pre-prod` (the AWS mirror) lands first so it can be verified, then Pages ships on
-approval. Each deploy assumes its own OIDC deployment role (`-deploy`). Creating a `v*` tag is
-also ruleset-protected — restricted to the maintainer — so releases can't be minted by accident.
-
-Two delivery planes, each with its own prod gate: **application/content** — `main` → staging ·
-`v*` → pre-prod → gated prod (GitHub Pages); **infrastructure** — `main` → staging applies
-automatically, `v*` → prod is plan-only (apply stays manual).
+**Prod is gated**: the Pages deploy runs behind a required reviewer in the `prod` GitHub
+environment — `pre-prod` (the AWS mirror) lands first, then Pages ships on approval. Two
+delivery planes, each with its own gate: **content** — `main` → staging · `v*` → pre-prod →
+gated Pages; **infrastructure** — `main` → staging auto-applies · `v*` → prod plan-only.
 
 ### Metrics — visitor analytics
 
@@ -94,16 +88,8 @@ flowchart TB
 ```
 
 `terraform/ci` creates the per-environment state backends and the OIDC roles GitHub Actions
-assumes to build and run the stacks. **Bootstrap is the one out-of-band step**: it runs once
-outside GitHub Actions, from an AWS user whose own IAM permissions create the state backends and
-the roles — no workflow is ever involved. From then on GitHub Actions assumes the OIDC roles
-directly, so no long-lived credentials are used by any workflow. **Operational extras
-(pluggable):** `toggle-env` flips staging CloudFront edges on/off; CloudFront invalidation
-purges the edge (inline in deploys, or manual via `invalidate-cloudfront.yml`).
-
-Cross-cutting security — OIDC only (no long-lived keys) · buckets never public (OAC) ·
-origin-gated metrics API · `pip-audit` on every build + CycloneDX SBOM per release
-([Security](#security)).
+assumes to build and run the stacks. **Bootstrap is the one out-of-band step** — an AWS user,
+outside GitHub Actions, creates them with its own IAM permissions; no workflow ever uses keys.
 
 ## Getting Started
 
@@ -143,9 +129,9 @@ the deployed one. Setup and first run are in [Getting Started](#getting-started)
 - **Live-reload dev server** — `compose.yaml` (podman, container `my-portfolio`) runs
   `scripts/serve.py`, an HTTPS-capable MkDocs dev server that also exposes `/health` (the
   container healthcheck curls it).
-- **HTTPS** — served over TLS with the local [mkcert](https://github.com/FiloSottile/mkcert) CA
-  (certs in `certs/`, gitignored); compose passes the cert paths to `serve.py`, which falls back
-  to plain HTTP with a warning if they're missing.
+- **HTTPS** — TLS via the local [mkcert](https://github.com/FiloSottile/mkcert) CA (certs in
+  `certs/`, gitignored); `serve.py` falls back to plain HTTP with a warning if the certs are
+  missing. Setup commands are in [Getting Started](#getting-started).
 - Commits to `main` are built, checked, and deployed automatically by GitHub Actions — see
   [CI / CD](#ci--cd).
 
@@ -167,113 +153,55 @@ flowchart LR
     X[workflow_dispatch] --> TG[toggle-env] & INV[invalidate]
 ```
 
-- **Build** (`.github/workflows/ci.yml`) — on every push/PR to `main` **and `v*` tags**: shared
-  build action (pip cache, `mkdocs build --strict`, `pip-audit` dependency audit, internal link
-  check, CSS sanity check) with the per-environment `site_url` (tags → prod, main → staging); uploads the built `site/` as an
-  artifact (7-day retention).
-- **Terraform checks** (`.github/workflows/checks-terraform.yml`) — static checks on the
-  terraform code (on pull requests, or manual dispatch — the stage checks skip, green, when
-  `terraform/**` isn't touched):
-  `terraform fmt -check`, `validate`
-  (all three roots: `terraform/`, `terraform/ci/`, `modules/metrics`), TFLint, and a Checkov
-  security scan (informational for now). No AWS credentials — this complements (does not
-  replace) the `terraform.yml` plan/apply pipeline.
-- **Per-surface checks** (`.github/workflows/checks-{shell,python,js,terraform,yml}.yml`) —
-  one workflow per surface, running on pull requests (or manual dispatch) with a job-level
-  relevance gate (`dorny/paths-filter`): when the PR touches none of the surface's files the
-  check **skips and reports success** — GitHub treats skipped jobs as success — so requiring all
-  checks never blocks unrelated PRs. Covers: `shellcheck` on `scripts/*.sh` + `.githooks/**`,
-  `ruff` on `**/*.py`, `node --check` on `**/*.js` (project + vendored), actionlint + YAML parse
-  on `**/*.yml`/`**/*.yaml` (workflow-file edits self-validate), and the terraform stage checks
-  on `terraform/**`.
-- **Local checks** (`check-compose.yaml`) — the same checks run locally as stage 1, one compose
-  service per check (`podman-compose -f check-compose.yaml run --rm <shell|python|yaml|yaml-syntax|js>`),
-  mirroring the GitHub workflows exactly (same commands + tool images). **Changed-files-only:**
-  `scripts/check_changed.sh` (pre-commit friendly; install with `git config core.hooksPath .githooks`).
-  The GitHub workflows remain the authoritative gate (stage 2).
-- **Deploy staging s3** (`.github/workflows/deploy-staging-s3.yml`) — on CI success for `main` pushes:
-  syncs the artifact to the **staging S3 bucket** (`<project>-staging-site`) with the S3-only
-  deploy role, then invalidates CloudFront with the edge-invalidate role (least privilege —
-  `STAGING_DEPLOY_ROLE_ARN` + `STAGING_INVALIDATE_ROLE_ARN`). The `staging` environment.
-  **Content-hash skip:** sync + invalidation are skipped when the artifact is byte-identical to
-  the last staging deploy (zero-byte marker objects keyed by content hash under `.deploy-hash/`,
-  existence-checked — content, not commits, is compared), so docs-only merges skip cleanly and
-  multi-commit batches can't leave staging stale.
-- **Deploy pre-prod s3** (`.github/workflows/deploy-pre-prod-s3.yml`) — on CI success for **`v*` tags only**:
-  syncs the artifact to the **prod S3 bucket** (`<project>-prod-site`) + CloudFront
-  invalidation (OIDC `PROD_DEPLOY_ROLE_ARN` + `PROD_INVALIDATE_ROLE_ARN`) — the **`pre-prod`**
-  environment (AWS mirror of the canonical site).
-- **Deploy prod pages** (`.github/workflows/deploy-prod-pages.yml`) — on CI success for **`v*` tags
-  only**: publishes the artifact to **GitHub Pages** (the public site at
-  <https://mathewmusango.github.io/my-portfolio/>) via the official Pages actions
-  (`configure-pages` → `upload-pages-artifact` → `deploy-pages`) — **least privilege**: only
-  `pages: write` + `id-token: write`, no `contents: write`; the **`prod`** environment. Requires
-  the repo Pages setting: source = **GitHub Actions** (flip right before the next `v*` deploy).
-- **Environments:** the deploy workflows declare per-environment environments — `staging` (auto,
-  ungated), `pre-prod` (AWS mirror), `prod` (GitHub Pages). Required reviewers are configured per
-  environment in Settings (recommended: required reviewer only on `prod`, so the mirror lands
-  first for verification and the canonical site follows on approval). Secrets stay repo-level for
-  now (`STAGING_*` / `PROD_*` prefixes); env-scoped secrets are a future idea.
-- **Toggle env** (`.github/workflows/toggle-env.yml` + `scripts/toggle_cloudfront.sh`) — manual
-  dispatch: **disable/enable STAGING CloudFront distributions** (component `site`|`metrics`,
-  action disable|enable) by flipping `Enabled` in place via the AWS CLI —
-  the invalidation-style toggle: no terraform apply runs, nothing can be deleted. **Staging only by
-  design** — prod has no toggle role (an accidental disable on the prod metrics edge would stop
-  collection). Uses the staging edge-toggle role (`STAGING_TOGGLE_ROLE_ARN`). Caveat: the flag
-  lives outside terraform state, so the next apply restores it to enabled.
-- **CloudFront invalidation** — the deploy jobs run their own **inline** `/*` invalidation
-  right after the sync (atomic with the deploy: lookup by the `<project>-<env>-site` comment
-  convention, skip when the distro is absent). Manual purges (out-of-band content changes) go
-  through `invalidate-cloudfront.yml` (`workflow_dispatch`) or locally via
-  `scripts/invalidate_cloudfront.sh <staging|prod> [paths]` — the reference implementation if
-  the inline steps are ever centralized:
+Each of the four phases below is documented in [`.github/workflows/README.md`](.github/workflows/README.md)
+(the implementation reference — triggers, roles, secrets) and
+[`CONTRIBUTING.md`](CONTRIBUTING.md) (the required-checks table):
 
-  ```sh
-  # Reference — the script used by the manual paths (also the centralized pattern)
-  scripts/invalidate_cloudfront.sh staging            # full invalidation (/*)
-  scripts/invalidate_cloudfront.sh prod "/about/ /metrics/"   # specific paths
-  ```
-- **Release** (`.github/workflows/release.yml`) — on `v*` tags (or manual dispatch): builds,
-  packages `site.zip`, generates a CycloneDX SBOM (`sbom.cdx.json`) from `requirements.txt`,
-  and creates/refreshes a GitHub Release with notes from `CHANGELOG.md`.
-
-Build and release workflows use only the auto-scoped `GITHUB_TOKEN`. Deploys and Terraform
-assume AWS roles via **OIDC** (no long-lived keys) using repo secrets: `STAGING/PROD_TERRAFORM_ROLE_ARN`,
-`STAGING/PROD_DEPLOY_ROLE_ARN`, `STAGING/PROD_INVALIDATE_ROLE_ARN`, `STAGING_TOGGLE_ROLE_ARN`,
-`PROJECT`, `AWS_REGION`, `STAGING/PROD_ALLOWED_ORIGIN`,
-`STAGING/PROD_METRICS_ENDPOINT`, `STAGING/PROD_SITE_URL`. No deployment value is hardcoded — terraform variables
-(`project`, `environment`, `aws_region`, `allowed_origin`, `tags`) are injected at runtime from
-secrets (CI) or `local.tfvars` (local dev).
+- **Build** (`ci.yml`) — strict `mkdocs build` + audits (pip-audit, link check) on every push/PR
+  to `main` and `v*` tags; uploads the built `site/` as an artifact.
+- **Checks** — one workflow per surface (`checks-{shell,python,js,terraform,yml}.yml`), gated on
+  PRs by relevance: untouched surfaces **skip and report success**, so the required checks never
+  block unrelated PRs. The same checks run locally (`check-compose.yaml` +
+  `scripts/check_changed.sh`).
+- **Deploy** — `workflow_run` on Build success: `main` → **staging** (S3 + CloudFront), `v*` tags
+  → **pre-prod** (AWS mirror) → gated **prod** (GitHub Pages). Staging **skips** when the
+  artifact is byte-identical to the last deploy (content-hash marker); prod runs in the `prod`
+  environment behind a required reviewer.
+- **Release & infra** — `v*` tags build a GitHub Release with a CycloneDX SBOM; `terraform.yml`
+  plans on `terraform/**` changes (apply stays manual); `toggle-env` and `invalidate-cloudfront`
+  are manual operational extras.
 
 ## Infrastructure as Code (Terraform)
 
-Real AWS infrastructure, defined with **Terraform** — a site + metrics stack:
+Real AWS infrastructure, defined with **Terraform** — [`terraform/README.md`](terraform/README.md)
+owes the full implementation (resources, event schema, security, local dev):
 
-- **Site (live)** — private S3 bucket + CloudFront (OAC, HTTP/2+3, localized error pages,
-  serving at `/`). The staging and prod sites deploy here via the workflows above; buckets are
-  **never public** (origin access control only).
-- **Metrics (live — both environments)** — API Gateway → Lambda → DynamoDB behind a
-  geo-enabled CloudFront edge (visitor country/city from CloudFront headers — no IPs are
-  stored, raw events expire after 90 days via DynamoDB TTL). **Free-Tier by default**: least-
-  privilege IAM, an edge origin-gate (403 for non-site origins, HTTPS only) and multi-origin
-  CORS (auto-includes the site's own CloudFront domain). WAF + a private VPC are opt-in behind
-  `enable_waf`/`enable_vpc`.
-- **Per-environment roles split by job (least privilege)**: `-terraform` (stack plan/apply,
-  tag-locked for prod) · `-deploy` (S3 content sync only) · `-invalidate` (edge purge) ·
-  `-toggle` (edge `Enabled` flip, staging only) — each workflow assumes only the role its step needs.
-- Applied via GitHub Actions using OIDC — the environment comes from the trigger (main →
-  staging, `v*` tags → prod). **Staging applies automatically on `main`; prod plans only — its
-  apply stays manual.** No state or secrets are ever committed; state lives in per-env private
-  S3 backends with DynamoDB locking.
-
-Deeper, stack-level documentation (resources, event schema, local Ministack workflow) lives in
-[`terraform/README.md`](terraform/README.md).
+- **Site** — private S3 + CloudFront (OAC only — buckets are never public, localized error
+  pages, serving at `/`), per environment; the deploys above sync the artifact into it.
+- **Metrics** — privacy-first visitor analytics: geo comes from CloudFront headers (no IPs
+  stored, 90-day TTL) via API Gateway → writer/reader lambdas → DynamoDB, origin-gated;
+  WAF / private VPC are opt-in.
+- **Control plane** — `terraform/ci` bootstraps the per-environment state backends (S3 +
+  DynamoDB lock) and the per-job OIDC roles (see [Architecture](#architecture)). Staging
+  applies automatically on `main`; prod applies stay manual. State/secrets are never committed.
 
 ## Security
 
 - See [SECURITY.md](SECURITY.md) for the vulnerability reporting policy.
 - **Dependabot** keeps `requirements.txt` (weekly) and GitHub Actions (monthly) up to date.
-- Every release ships an SBOM, and `pip-audit` runs on every CI build.
+- Every release ships a CycloneDX SBOM, and `pip-audit` runs on every CI build.
+- No long-lived keys anywhere — deploys and Terraform assume AWS roles via OIDC; buckets are
+  never public (OAC only) and the metrics API is origin-gated (details in
+  [`terraform/README.md`](terraform/README.md)).
+
+## Documentation map
+
+- [`README.md`](README.md) — this file: the system view (what the repo is, architecture, running it locally).
+- [`terraform/README.md`](terraform/README.md) — infrastructure implementation (site + metrics stacks, event model, security, local AWS emulation).
+- [`.github/workflows/README.md`](.github/workflows/README.md) — CI/CD implementation (every workflow, naming, roles, secrets, ops extras).
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — process: branching, required-checks table, issues/labels, releases.
+- [`SECURITY.md`](SECURITY.md) — vulnerability reporting.
+- [`CHANGELOG.md`](CHANGELOG.md) — release history.
 
 ## License
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -8,11 +8,27 @@ staging and prod run the full stack.
 It does **not** build the MkDocs application: GitHub Actions builds the site artifact; Terraform
 provisions and manages the infrastructure that serves it and collects telemetry.
 
+```mermaid
+flowchart TB
+    subgraph OOB[Out-of-band — once per environment, as an AWS user]
+        U[AWS user] -->|scripts/bootstrap_aws.sh| CI[terraform/ci<br/>OIDC provider · state backends · roles]
+    end
+    CI --> STATE[(state backends — S3 + DynamoDB lock<br/>staging · prod · local Ministack)]
+    CI --> ROLES[OIDC roles — least privilege, one per job<br/>-terraform · -deploy · -invalidate · -toggle]
+    subgraph GHA[GitHub Actions]
+        WF[terraform.yml] -->|assumes| ROLES
+    end
+    ROLES -->|plan · apply| SITE[site — S3 + CloudFront OAC<br/>staging · prod]
+    ROLES -->|plan · apply| MET[metrics — CF geo → API GW<br/>→ Lambda writer + reader → DynamoDB<br/>staging own stack · pre-prod + prod shared]
+```
+
+The AWS-side picture at a glance — the details follow. (`pre-prod` deploys content onto the
+**prod** stack; it is not a separate Terraform environment.)
+
 ## Design principles
 
-1. **No long-lived CI credentials** — GitHub Actions assumes OIDC roles, one per job. The one-time
-   `terraform/ci` bootstrap runs **outside GitHub Actions, as an AWS user** (its own IAM
-   permissions create the roles); no workflow ever uses keys.
+1. **No long-lived CI credentials** — GitHub Actions assumes OIDC roles, one per job; only the
+   one-time `terraform/ci` bootstrap runs as an AWS user (see the map above).
 2. **Least-privilege IAM** — roles split by responsibility, scoped to their own resources.
 3. **Private object storage** — site buckets are never public; served only through CloudFront OAC.
 4. **Privacy-first telemetry** — geo from CloudFront headers only, no IPs stored, bounded retention (DynamoDB TTL).
@@ -20,12 +36,9 @@ provisions and manages the infrastructure that serves it and collects telemetry.
 
 > Single repo (`mathewmusango/my-portfolio`). `terraform.yml` plans on any change to
 > `terraform/**`: **main → staging (auto-apply), `v*` tags → prod (plan only — apply stays
-> manual)**. `toggle-env.yml` + `scripts/toggle_cloudfront.sh` (manual dispatch) flip `Enabled`
-> on STAGING CloudFront distributions in place — component `site`|`metrics` × `disable|enable` —
-> the invalidation-style toggle: no terraform apply, nothing deleted. Staging only by design —
-> prod has no toggle role. Caveat: the flag lives outside terraform state — the next apply
-> restores it to enabled. Local dev applies against Ministack; real-AWS applies happen via the
-> workflow (OIDC) or the CLI.
+> manual)**. Local dev applies against Ministack; real-AWS applies happen via the workflow
+> (OIDC) or the CLI. Ops extras (`toggle-env`, `invalidate-cloudfront`) are documented in
+> [`.github/workflows/README.md`](../.github/workflows/README.md).
 
 > **On `pre-prod`:** the root README's deploy pipeline has a third stage, `pre-prod` — an
 > AWS-hosted mirror of the canonical site, used to verify a release before it ships to GitHub
@@ -46,13 +59,8 @@ That keeps the whole geo pipeline AWS-native: no GeoIP database, no license keys
 **no IP address ever stored** (the function only ever sees the headers CloudFront
 provides — the visitor's raw IP never reaches DynamoDB).
 
-```mermaid
-flowchart LR
-    S[Site browser] -->|POST /event| CF[CloudFront<br/>geo headers added]
-    CF -->|GET /summary · GET /health| GW[API Gateway HTTP API]
-    GW --> FN[Lambda collector]
-    FN -->|put_item / scan| DB[(DynamoDB<br/>PAY_PER_REQUEST + TTL)]
-```
+Pipeline map: the root README's [Metrics section](../README.md#metrics--visitor-analytics) shows
+the two-lambda flow (writer/reader) end to end.
 
 ## Resources
 
@@ -98,9 +106,9 @@ The beacon sends a tiny JSON body; the collector whitelists fields and enriches:
 
 ## Read path (`GET /summary`)
 
-The collector scans recent events and aggregates in memory: `total`,
-`by_country`, `by_page`, `by_lang`. This is fine at portfolio traffic levels
-(scan cap 5000). **Follow-up**: a counters table fed by DynamoDB Streams, so
+The collector scans recent events and aggregates in memory — `total`, `by_country`,
+`by_page`, `by_lang`, `by_ref`, `by_hour`/`by_day`, `by_device`, `by_type`, and
+`clicks`. Fine at portfolio traffic levels (scan cap 5000). **Follow-up**: a counters table fed by DynamoDB Streams, so
 `/summary` becomes O(1) point reads — no scan.
 
 ## Deploy
@@ -126,32 +134,15 @@ the same values from CI secrets at plan time; nothing is hardcoded in `*.tf`.
 credentials at all** — CloudFront is a public HTTPS edge; the browser beacon
 just `POST`s to it, allowed by CORS from the site origin.
 
-### Real AWS (production)
+### Applying to real AWS
 
-```sh
-cd terraform
-terraform init          # downloads aws + archive providers
-# Authenticate via your normal chain — see "Credentials & endpoints" above.
-#
-# Deployment values are injected, never hardcoded in *.tf. Only `environment`
-# and `allowed_origin` vary per env (CI: STAGING/PROD_ALLOWED_ORIGIN);
-# `project`, `aws_region` and `tags` are shared across environments
-# (CI: the PROJECT + AWS_REGION secrets). Export them once per environment as
-# TF_VAR_* — here, prod (main → staging would set environment=staging):
-export TF_VAR_project=my-portfolio
-export TF_VAR_aws_region=us-east-1
-export TF_VAR_environment=prod
-export TF_VAR_allowed_origin=https://mathewmusango.github.io
-export TF_VAR_tags='{"project":"my-portfolio","managed_by":"terraform","repo":"mathewmusango/my-portfolio"}'
-terraform plan -out=tf.plan     # values come from the environment — no -var flags
-terraform apply tf.plan
-terraform output api_url         # → https://<cloudfront>.cloudfront.net  ← beacon endpoint
-```
+Real-AWS applies run through GitHub Actions (`terraform.yml`): staging auto-applies on `main`;
+prod applies are manual dispatches — both via OIDC, no keys in workflows (see the auth model in
+[`.github/workflows/README.md`](../.github/workflows/README.md)). Manual CLI applies exist only
+for rare out-of-band work (e.g., a catch-up) and are documented in the project's **private
+runbook** — intentionally not in this public repo.
 
-- CloudFront is ON by default (`enable_cloudfront = true`) — it is what adds the
-  geo headers. **Cost:** PAY_PER_REQUEST table (no idle cost at low traffic) +
-  Lambda + CloudFront — low, usage-driven operating cost at portfolio scale;
-  CloudFront data transfer is the main line.
+CloudFront is ON by default (`enable_cloudfront = true`) — it is what adds the geo headers.
 
 ### Local dev (Ministack / LocalStack)
 
@@ -178,8 +169,9 @@ it has **no real edge locally** — `https://<dist>.cloudfront.net` only resolve
 on real AWS. So the local site beacon uses `api_gateway_url`
 (`http://<api-id>.execute-api.localhost:4566`) and geo fields read `"unknown"`.
 
-Then verify the pipeline (LocalStack's own `/health` shadows the API's `/health`
-route locally — test with `/event` and `/summary` instead):
+Then verify the pipeline (Ministack's own `/health` on 4566 shadows the API's
+`GET /health` locally — test with `/event` and `/summary` instead; `/health` is
+reachable on real AWS):
 
 ```sh
 # The origin gate is HTTPS-only — cleartext origins are always rejected. The
@@ -190,9 +182,6 @@ curl -X POST http://<api-id>.execute-api.localhost:4566/event \
   -d '{"type":"pageview","page":"/","lang":"en"}'
 curl http://<api-id>.execute-api.localhost:4566/summary -H 'Origin: https://portfolio.mathewmusango.test:8000'
 ```
-
-> The API Gateway route `GET /health` is deployed but locally shadowed by
-> Ministack's own health check on port 4566 — reachable on real AWS.
 
 ### Backend (state)
 
@@ -215,8 +204,8 @@ terraform init \
 ```
 
 CI does the same automatically: bucket and lock names are derived from the
-`PROJECT` secret + the trigger-resolved environment (main → staging, `v*` tags →
-prod), region from the `AWS_REGION` secret — all secrets, nothing in the repo.
+shared project secret + the trigger-resolved environment (main → staging, `v*` tags →
+prod), region from the AWS-region secret — all secrets, nothing in the repo.
 Local dev points at the bucket via `AWS_ENDPOINT_URL` (Ministack) or real S3.
 
 ## Site integration
@@ -230,7 +219,7 @@ The backend is wired to the site:
   Empty endpoint = beacon no-ops (prod, until the real stack deploys). The dev
   container passes the host's `METRICS_ENDPOINT` through (`compose.yaml`).
   **Endpoint by environment:** local dev → `terraform output api_gateway_url`
-  (Ministack has no real edge); real AWS prod → `terraform output api_url`
+  (Ministack has no real edge); real AWS staging and prod → `terraform output api_url`
   (`https://<cloudfront>.cloudfront.net`) — the public edge the browser hits.
 - **Per-page counter** — `GET /views?page=<path>` exists (a Query on the
   `page-date-index` GSI — no full scan per page load) for per-page counts;
@@ -239,13 +228,8 @@ The backend is wired to the site:
   `GET /summary` and renders live totals + top pages; labels stay in the page
   markup so they translate per language. The "Visitor analytics" card is Live.
 
-```js
-// Beacon payload (what actually lands in DynamoDB)
-{ "type": "pageview", "page": "/my-portfolio/metrics/", "lang": "en" }
-```
-
-Uptime = external probes hitting `/health`; Performance = future
-`type: "webvitals"` events.
+Uptime = external probes hitting `/health`. `type: "webvitals"` events are already captured by
+the writer (`metric`/`value`, timings); surfacing them on the metrics page is future work.
 
 ## Security (Free-Tier defaults, opt-in hardening)
 
@@ -290,7 +274,6 @@ still applies.
   chain.
 - **Test vs prod**: local dev applies with `environment = "test"` (see
   `local.tfvars`) — resource names and the table are prefixed, so both can
-  coexist. **Terraform runs via GitHub Actions** — `.github/workflows/terraform.yml`
-  plans on any change to `terraform/**`; staging auto-applies on `main` pushes,
-  prod plans on `v*` tags and applies only via manual dispatch (OIDC —
-  `STAGING/PROD_TERRAFORM_ROLE_ARN` + `AWS_REGION` secrets).
+  coexist. **Terraform runs via GitHub Actions** — `terraform.yml` plans on
+  `terraform/**` changes; staging auto-applies on `main`, prod applies manually
+  (see the map above + `.github/workflows/README.md` for roles/secrets).


### PR DESCRIPTION
## What does this PR do?

Implements the #24 docs split: root `README.md` becomes the **system view**, CI/CD implementation detail moves next to the code.

- **`README.md`** — `## CI / CD` slimmed from ~75 lines of workflow mechanics to the lifecycle mermaid + four one-line phases (Build / Checks / Deploy / Release & infra), each pointing at the implementation reference; SBOM + AWS-auth badges removed (absorbed from #33); Architecture prose trimmed (Site + Terraform control-plane paragraphs); **Infrastructure as Code** section condensed (duplicates removed); Security gained one consolidated OIDC/private-buckets/origin-gate bullet; new **Documentation map** section.
- **`.github/workflows/README.md` (new)** — the CI/CD implementation reference: naming conventions, Build/Checks/Deploy/Release/Infra detail, the content-hash skip deep-dive, ops extras, and an **auth model** (mermaid + placeholder secret patterns `{ENV}_*` — no real secret names in a public repo).
- **`terraform/README.md`** — audit pass: top-level overview mermaid added; stale one-Lambda mermaid removed; duplication trimmed (toggle mechanics, cost notes, `/health` shadow, env-model repeats); staleness fixed (`/summary` aggregations, webvitals wording, endpoint-by-env + staging); "Real AWS (production)" CLI runbook replaced with a workflow-first paragraph (runbook relocated to the project's private notes).
- **`CONTRIBUTING.md`** — pointer to the workflows README; corrected `checks-python-ruff` (repo-wide) and `checks-yaml-actionlint` (`.github/workflows/**` only) rows.

Accuracy was verified by audit against the actual workflow files (triggers, roles/secrets references, environment declarations, checks job names).

## Related issue(s)

Closes #24

## Type of change

- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [ ] Governance (process / rules / templates) — `governance`
- [x] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a (repo docs)
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — repo docs only; no site pages or workflow behavior changes
- [x] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (docs-only, no tag)
