### PR TITLE
chore: branch + tag rulesets as code (main · v*) (#25)

### DIFF
--- a/rulesets/main.json
+++ b/rulesets/main.json
@@ -1,0 +1,87 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "require_extra_approval_for_unattributed_changes": true,
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "ci-build",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-js-node-check",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-python-ruff",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-shell-shellcheck",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-terraform-fmt",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-terraform-lint",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-terraform-security",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-terraform-validate",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-yaml-actionlint",
+            "integration_id": 15368
+          },
+          {
+            "context": "checks-yaml-syntax",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/rulesets/tags.json
+++ b/rulesets/tags.json
@@ -1,0 +1,44 @@
+{
+  "name": "release tags (v*)",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/v*"
+      ]
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ci-build",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Adds branch + tag rulesets as code, in GitHub's **export/import format** (round-trippable via the Rulesets UI import or `gh api`).

- **`rulesets/main.json`** — branch ruleset on `refs/heads/main`: PR-only with 1 required approval (2nd account), the 10 required status checks (strict, with their `integration_id`), no deletions / no force-pushes, no bypass. Hardening vs the current live ruleset: `dismiss_stale_reviews_on_push: true`, `required_review_thread_resolution: true`, `allowed_merge_methods: [squash, rebase]`.
- **`rulesets/tags.json`** — tag ruleset on `refs/tags/v*`: `ci-build` required on the tagged commit (`do_not_enforce_on_create: false` — must be false on tags or enforcement never runs), creation/deletion/force-update restricted to the repo-admin bypass (maintainer), so releases can't be minted by accident.

Applying to the repo stays **out-of-band** (the live `main` ruleset exists — update via `gh api --method PUT .../rulesets/22026993 --input rulesets/main.json`; tags: import/update). The PR ships the reviewed, versioned source of truth.

## Related issue(s)

Closes #25

## Type of change

- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [x] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — new `rulesets/` folder only
- [x] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (repo governance, no site change)
