### PR TITLE
docs: ruleset verification records beside their config (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ owes the full implementation (resources, event schema, security, local dev):
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — process: branching, required-checks table, issues/labels, releases.
 - [`SECURITY.md`](SECURITY.md) — vulnerability reporting.
 - [`CHANGELOG.md`](CHANGELOG.md) — release history.
+- [`rulesets/`](rulesets/) — branch/tag rulesets as code + their verification records (`main.md` · `tags.md`).
 
 ## License
 

--- a/rulesets/main.md
+++ b/rulesets/main.md
@@ -1,0 +1,20 @@
+# Ruleset: `main` — verification
+
+**Last verified:** 2026-09-04 · **Status:** 🟢 verified · **Relates to:** #25, #37 · **Config:** [`main.json`](main.json)
+
+**Purpose.** `main` binds every actor — PR-only, 1 approval, squash/rebase, all 10 checks, zero
+bypass.
+
+**Method.** Direct-push attempts of a scratch commit to `refs/heads/main`, as admin and as the
+write collaborator. Rejected pushes are side-effect-free.
+
+**Result.**
+
+| Actor | Outcome |
+| --- | --- |
+| admin (`mathewmusango`) | 🔴 rejected — "Changes must be made through a pull request" + "10 of 10 required status checks are expected" |
+| collaborator (`kizingainc`) | 🔴 rejected — same |
+
+Remote unchanged afterwards.
+
+**Lesson.** The only path to `main` is PR → approval → squash — the owner included.

--- a/rulesets/tags.md
+++ b/rulesets/tags.md
@@ -1,0 +1,19 @@
+# Ruleset: `v*` tags — verification
+
+**Last verified:** 2026-09-04 · **Status:** 🟢 verified · **Relates to:** #25 · **Config:** [`tags.json`](tags.json)
+
+**Purpose.** `v*` tags are minted only by the maintainer (admin bypass) and only on commits with
+green `ci-build`; everyone else is bound by both rules.
+
+**Method.** `v*` tag push attempts as the write collaborator (rejected, side-effect-free) and as
+admin (accepted — fires the pipeline; exercised once, runs cancelled, cleaned up).
+
+**Result.**
+
+| Actor | Outcome |
+| --- | --- |
+| collaborator (`kizingainc`) | 🔴 rejected — "Cannot create ref due to creations being restricted" + "Required status check 'ci-build' is expected" |
+| admin (`mathewmusango`) | 🟢 accepted (bypass notice) — by design for releases |
+
+**Lesson.** Enforcement binds non-bypass actors only — a negative admin test is impossible by
+design; the tag-guard process is the admin-side gate.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Tests & Verification Records
+
+Records are classified by **category → target**; each file follows one template (**Last
+verified · Status · Relates to · Config/Target** + **Purpose · Method · Result · Lesson**) and is
+updated in the PR that changes the behavior. Steps/identity mechanics stay private.
+
+| Category | Target | Rules / behavior covered | Status |
+| --- | --- | --- | --- |
+| Rulesets | [`main`](rulesets/main.md) | PR-only · 1 approval · squash/rebase · 10 checks · no creation / deletion / force-push · no bypass | 🟢 verified |
+| Rulesets | [`v*` tags](rulesets/v.md) | creation = maintainer only · `ci-build` required · no deletion / force-move · admin bypass | 🟢 verified |

--- a/tests/rulesets/main.md
+++ b/tests/rulesets/main.md
@@ -1,0 +1,20 @@
+# Ruleset: `main` — verification
+
+**Last verified:** 2026-09-04 · **Status:** 🟢 verified · **Relates to:** #25, #37 · **Config:** [`rulesets/main.json`](../rulesets/main.json)
+
+**Purpose.** `main` binds every actor — PR-only, 1 approval, squash/rebase, all 10 checks, zero
+bypass.
+
+**Method.** Direct-push attempts of a scratch commit to `refs/heads/main`, as admin and as the
+write collaborator. Rejected pushes are side-effect-free.
+
+**Result.**
+
+| Actor | Outcome |
+| --- | --- |
+| admin (`mathewmusango`) | 🔴 rejected — "Changes must be made through a pull request" + "10 of 10 required status checks are expected" |
+| collaborator (`kizingainc`) | 🔴 rejected — same |
+
+Remote unchanged afterwards.
+
+**Lesson.** The only path to `main` is PR → approval → squash — the owner included.

--- a/tests/rulesets/v.md
+++ b/tests/rulesets/v.md
@@ -1,0 +1,19 @@
+# Ruleset: `v*` tags — verification
+
+**Last verified:** 2026-09-04 · **Status:** 🟢 verified · **Relates to:** #25 · **Config:** [`rulesets/tags.json`](../rulesets/tags.json)
+
+**Purpose.** `v*` tags are minted only by the maintainer (admin bypass) and only on commits with
+green `ci-build`; everyone else is bound by both rules.
+
+**Method.** `v*` tag push attempts as the write collaborator (rejected, side-effect-free) and as
+admin (accepted — fires the pipeline; exercised once, runs cancelled, cleaned up).
+
+**Result.**
+
+| Actor | Outcome |
+| --- | --- |
+| collaborator (`kizingainc`) | 🔴 rejected — "Cannot create ref due to creations being restricted" + "Required status check 'ci-build' is expected" |
+| admin (`mathewmusango`) | 🟢 accepted (bypass notice) — by design for releases |
+
+**Lesson.** Enforcement binds non-bypass actors only — a negative admin test is impossible by
+design; the tag-guard process is the admin-side gate.


### PR DESCRIPTION
## What does this PR do

Adds verification records for the branch/tag rulesets, **beside their config** (a dedicated tests folder returns later when there are more categories):

- `rulesets/main.md` — 🟢 verified: `main` binds every actor (PR-only + 10 checks, no bypass)
- `rulesets/tags.md` — 🟢 verified: creation = maintainer only + `ci-build` required; admin bypass by design
- `rulesets/` folder now reads: `main.json` + `main.md` · `tags.json` + `tags.md` (config + record colocated)
- Root `README.md` Documentation map lists `rulesets/` (as code + records)

Each record follows a common template (**Last verified · Status · Relates to · Config** + Purpose · Method · Result · Lesson), updated in the PR that changes the target's config. Steps and identity mechanics are deliberately private.

## Related issue(s)

Closes #36

## Type of change

- [x] Docs — `documentation`
- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [ ] Governance (process / rules / templates) — `governance`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — rulesets/ docs only
- [x] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (docs)