### PR TITLE
chore: rulesets as-code reconcile — main gains creation rule (#37)

### DIFF
--- a/rulesets/main.json
+++ b/rulesets/main.json
@@ -81,6 +81,9 @@
           }
         ]
       }
+    },
+    {
+      "type": "creation"
     }
   ],
   "bypass_actors": []


### PR DESCRIPTION
## What does this PR do

Reconciles `rulesets/main.json` with the live `main` ruleset, which was updated in the UI to add the **`creation`** restriction (restrict creations/updates/deletions on the default branch). The as-code file was behind live — a future PUT would have regressed it.

- Adds the `creation` rule to `rulesets/main.json` (rules now: deletion · non_fast_forward · pull_request · required_status_checks · creation).
- No bypass actors — the admin stays bound to PR-only (verified: direct pushes to `main` are rejected even for the owner).

No live changes needed — live already has the rule (verified via API).

## Related issue(s)

Closes #37

## Type of change

- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [ ] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [x] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — `rulesets/main.json` only
- [x] Local checks pass for the touched surfaces (CI will verify)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (repo governance)
