### PR TITLE
ci: ruleset drift-check — fail when rulesets/*.json diverge from live (#42)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,6 +43,10 @@ secrets it uses, and the gotchas. The **system view** (how a change ships) lives
   identical commands + tool images); `scripts/check_changed.sh` runs changed-files-only
   (pre-commit friendly: `git config core.hooksPath .githooks`). The GitHub workflows remain the
   authoritative gate.
+- **`checks-rulesets.yml` (`Checks: Rulesets`)** — ruleset **drift check**: `scripts/check_ruleset_drift.py`
+  compares each `rulesets/*.json` (config-as-code) against the live ruleset via the API
+  (normalized: runtime fields dropped, list order insignificant). Runs on main merges touching
+  `rulesets/**`, on a daily schedule (catches UI-side edits), and manually. No auto-apply.
 
 ## Deploy — `workflow_run` on Build success
 

--- a/.github/workflows/checks-rulesets.yml
+++ b/.github/workflows/checks-rulesets.yml
@@ -1,0 +1,40 @@
+name: "Checks: Rulesets"
+
+# Drift check: rulesets/*.json (config-as-code) must match the live rulesets.
+# Runs on main merges touching rulesets/, on a schedule (catches UI-side edits),
+# and manually. No auto-apply — applying stays an explicit `gh api` PUT.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ["rulesets/**"]
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare as-code rulesets with live
+        run: |
+          set -euo pipefail
+          for file in rulesets/*.json; do
+            name="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["name"])' "$file")"
+            id="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --jq ".[] | select(.name == \"$name\") | .id")"
+            if [ -z "$id" ]; then
+              echo "::error::ruleset '$name' ($file) is not live — apply it (gh api PUT)"
+              exit 1
+            fi
+            gh api "repos/${GITHUB_REPOSITORY}/rulesets/$id" > /tmp/live.json
+            if ! python3 scripts/check_ruleset_drift.py "$file" /tmp/live.json; then
+              echo "::error::drift: $file does not match live ruleset '$name' (id $id)"
+              exit 1
+            fi
+            echo "ok: $file matches live '$name'"
+          done

--- a/scripts/check_ruleset_drift.py
+++ b/scripts/check_ruleset_drift.py
@@ -1,0 +1,65 @@
+"""Compare an as-code ruleset file with the live GitHub ruleset (drift check).
+
+Usage: check_ruleset_drift.py <as-code.json> <live.json>
+
+Exits 0 when the rulesets match after normalization; prints the canonical
+forms and exits 1 when they drift.
+"""
+
+import json
+import sys
+
+# Fields GitHub adds at runtime that are not part of the config-as-code.
+RUNTIME_KEYS = {
+    "id",
+    "source_type",
+    "source",
+    "updated_at",
+    "created_at",
+    "node_id",
+    "url",
+    "html_url",
+    "_links",
+    "current_user_can_bypass",
+}
+
+
+def _dump(obj):
+    return json.dumps(obj, sort_keys=True)
+
+
+def _canonical(obj):
+    """Recursively normalize: drop runtime keys and empty/null values, and
+    make list order insignificant (rules/checks/bypass order doesn't matter)."""
+    if isinstance(obj, dict):
+        return {
+            key: _canonical(value)
+            for key, value in obj.items()
+            if key not in RUNTIME_KEYS and value not in (None, [], {})
+        }
+    if isinstance(obj, list):
+        return sorted((_canonical(item) for item in obj), key=_dump)
+    return obj
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        as_code = json.load(handle)
+    with open(sys.argv[2], encoding="utf-8") as handle:
+        live = json.load(handle)
+    as_code_norm = _canonical(as_code)
+    live_norm = _canonical(live)
+    if as_code_norm == live_norm:
+        print("match")
+        return 0
+    print("drift:")
+    print("file:", _dump(as_code_norm))
+    print("live:", _dump(live_norm))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What does this PR do

Adds the ruleset drift-check so config-as-code can't silently diverge from the live rulesets:

- **`.github/workflows/checks-rulesets.yml`** (`Checks: Rulesets`) — runs on main merges touching `rulesets/**`, on a **daily schedule** (catches UI-side edits like the one that added `creation` + an admin bypass to `main` unnoticed), and via `workflow_dispatch`. No auto-apply — applying stays an explicit `gh api` PUT.
- **`scripts/check_ruleset_drift.py`** — compares each `rulesets/*.json` against the live ruleset (matched by name): normalizes both sides (drops runtime fields like `id`/`_links`/`current_user_can_bypass`, makes list order insignificant) and exits non-zero on drift with the canonical diff.

Validated locally against live: both rulesets `match`; a simulated drift (merge-method change) is detected.

## Related issue(s)

Closes #42

## Type of change

- [ ] Content (page / translation / asset) — `enhancement`
- [ ] Feature — `enhancement`
- [ ] Fix — `bug`
- [x] CI / tooling — `ci`
- [ ] Infra (Terraform / AWS) — `infra`
- [ ] Security — `security`
- [x] Governance (process / rules / templates) — `governance`
- [ ] Docs — `documentation`
- [ ] Dependencies — `dependencies`

## Checklist

- [x] `main` is up to date and this branch is based on it
- [ ] English content changes come with `es` / `zh` translations (content only) — n/a
- [x] Page-scoped changes — no other pages affected (or blast radius checked) — new workflow + script + workflows README
- [x] Local checks pass for the touched surfaces (CI will verify — actionlint, ruff on the script)
- [ ] CHANGELOG updated if this is a user-visible change — n/a (repo tooling)
