### PR TITLE
ci: fix check-compose local checks + add scripts/check_local.sh driver

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,8 +40,10 @@ secrets it uses, and the gotchas. The **system view** (how a change ships) lives
 - **Required checks are the job names** — see the table in `CONTRIBUTING.md` (the `main`
   ruleset enforces them).
 - **Local parity:** `check-compose.yaml` mirrors the workflows exactly (one service per check,
-  identical commands + tool images); `scripts/check_changed.sh` runs changed-files-only
-  (pre-commit friendly: `git config core.hooksPath .githooks`). The GitHub workflows remain the
+  identical commands + tool images). `scripts/check_local.sh` is the one-entry driver — default
+  runs every surface whose files changed (diff-gated, mirroring the CI skip-model); `--full` runs
+  all surfaces on the whole repo. `scripts/check_changed.sh` is the pre-commit fast path
+  (changed-files only: `git config core.hooksPath .githooks`). The GitHub workflows remain the
   authoritative gate.
 
 ## Deploy — `workflow_run` on Build success

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Each of the four phases below is documented in [`.github/workflows/README.md`](.
   to `main` and `v*` tags; uploads the built `site/` as an artifact.
 - **Checks** — one workflow per surface (`checks-{shell,python,js,terraform,yml}.yml`), gated on
   PRs by relevance: untouched surfaces **skip and report success**, so the required checks never
-  block unrelated PRs. The same checks run locally (`check-compose.yaml` +
-  `scripts/check_changed.sh`).
+  block unrelated PRs. The same checks run locally (`scripts/check_local.sh` — changed-files by
+  default, `--full` for whole-repo, mirroring the workflows exactly).
 - **Deploy** — `workflow_run` on Build success: `main` → **staging** (S3 + CloudFront), `v*` tags
   → **pre-prod** (AWS mirror) → gated **prod** (GitHub Pages). Staging **skips** when the
   artifact is byte-identical to the last deploy (content-hash marker); prod runs in the `prod`

--- a/check-compose.yaml
+++ b/check-compose.yaml
@@ -1,12 +1,19 @@
 # Local (stage-1) checks — one service per check, mirroring the checks-*.yml
-# GitHub workflows EXACTLY (same commands, purpose-built tool images). Run one:
+# GitHub workflows EXACTLY (same commands, purpose-built tool images).
+#
+# Preferred entry point — scripts/check_local.sh (drives these services,
+# diff-gated by default, --full for a whole-repo pass, per-surface selection):
+#   scripts/check_local.sh          # all surfaces, changed files only
+#   scripts/check_local.sh --full   # all surfaces, whole repo
+#
+# Raw compose loop (same thing, no driver):
 #   podman-compose -f check-compose.yaml run --rm <service>
 # or all, one after another:
 #   for svc in shell python yaml yaml-syntax js terraform-fmt terraform-validate \
 #              terraform-lint terraform-security; do
 #     podman-compose -f check-compose.yaml run --rm "$svc" || exit 1
 #   done
-# Changed-files-only: scripts/check_changed.sh (pre-commit friendly).
+# Pre-commit per-file fast path: scripts/check_changed.sh.
 # The GitHub workflows remain the authoritative gate (stage 2 — attested,
 # per-commit results). All scans are extension-wide across the whole repo
 # (site/ + .git excluded) so NEW files in new locations are never missed.

--- a/check-compose.yaml
+++ b/check-compose.yaml
@@ -11,6 +11,14 @@
 # per-commit results). All scans are extension-wide across the whole repo
 # (site/ + .git excluded) so NEW files in new locations are never missed.
 # First run pulls the tool images (network).
+#
+# Compose gotchas handled here:
+#   - "$f" must be written "$$f" — compose interpolates $VAR from the host env
+#     at parse time, which emptied loop variables and silently skipped every
+#     file. Image ENTRYPOINTs differ per tool: some run the tool directly
+#     (ruff, actionlint, terraform, tflint), some wrap it (checkov's
+#     /entrypoint.sh already execs checkov). Commands below match each image's
+#     entrypoint so the tool is invoked exactly once.
 name: repo_check
 services:
   shell:
@@ -21,69 +29,81 @@ services:
     command: ["sh", "-c", "find . -path './site' -prune -o -path './.git' -prune -o -type f \\( -name '*.sh' -o -path './.githooks/*' \\) -print0 2>/dev/null | xargs -0 -r shellcheck -S warning"]
 
   python:
-    # ruff-action@v1 runs `ruff check .` — same command here (the action only
+    # ruff-action@v3 runs `ruff check .` — same command here (the action only
     # adds --output-format github for annotations, meaningless locally).
+    # --no-cache: the repo is mounted read-only and ruff would otherwise try to
+    # write .ruff_cache/ into it.
     image: ghcr.io/astral-sh/ruff:latest
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["check", "."]
+    command: ["check", ".", "--no-cache"]
 
   yaml:
-    # raven-actions/actionlint@v2 runs `actionlint -verbose` (+ matcher /
-    # embedded shellcheck) — -no-color matches the workflow's non-TTY output.
-    image: ghcr.io/rhysd/actionlint:latest
+    # raven-actions/actionlint@v2 runs `actionlint` — docker.io mirror (the
+    # ghcr.io registry returned HTTP 403 on this box). -no-color matches the
+    # workflow's non-TTY output.
+    image: docker.io/rhysd/actionlint:latest
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["-verbose", "-no-color"]
+    command: ["-no-color"]
 
   yaml-syntax:
     image: docker.io/library/ruby:alpine
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["sh", "-c", "find . -path './site' -prune -o -path './.git' -prune -o -type f \\( -name '*.yml' -o -name '*.yaml' \\) -print 2>/dev/null | while IFS= read -r f; do ruby -ryaml -e \"YAML.load_file(ARGV[0])\" \"$f\"; echo \"ok: $f\"; done"]
+    command: ["sh", "-c", "find . -path './site' -prune -o -path './.git' -prune -o -type f \\( -name '*.yml' -o -name '*.yaml' \\) -print 2>/dev/null | while IFS= read -r f; do ruby -ryaml -e \"YAML.load_file(ARGV[0])\" \"$$f\" || { echo \"FAILED: $$f\"; exit 1; }; done || exit 1; echo 'yaml-syntax: all files parsed'"]
 
   js:
     image: docker.io/library/node:alpine
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["sh", "-c", "find . -path './site' -prune -o -path './.git' -prune -o -type f -name '*.js' -print0 2>/dev/null | while IFS= read -r -d '' f; do node --check \"$f\"; echo \"ok: $f\"; done"]
+    command: ["sh", "-c", "find . -path './site' -prune -o -path './.git' -prune -o -type f -name '*.js' -print0 2>/dev/null | while IFS= read -r -d '' f; do node --check \"$$f\" || { echo \"FAILED: $$f\"; exit 1; }; done || exit 1; echo 'js: all files syntax-checked'"]
 
   terraform-fmt:
     # checks-terraform fmt job: terraform fmt -check -recursive -diff terraform/
-    image: hashicorp/terraform:1.15.9
+    # The image ENTRYPOINT is /bin/terraform — args only, no leading tool name.
+    image: docker.io/hashicorp/terraform:1.15.9
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["terraform", "fmt", "-check", "-recursive", "-diff", "terraform/"]
+    command: ["fmt", "-check", "-recursive", "-diff", "terraform/"]
 
   terraform-validate:
     # checks-terraform validate job (all three roots). TF_DATA_DIR keeps init's
     # .terraform out of the read-only mount; -lockfile=readonly uses the
-    # committed lockfiles (all three roots now have one).
-    image: hashicorp/terraform:1.15.9
+    # committed lockfiles (all three roots now have one). The image ENTRYPOINT
+    # is /bin/terraform, so the sh -c wrapper runs terraform from PATH.
+    image: docker.io/hashicorp/terraform:1.15.9
+    entrypoint: ["/bin/sh", "-c"]
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["sh", "-c", "TF_DATA_DIR=/tmp/tf-root terraform -chdir=terraform init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-root terraform -chdir=terraform validate -no-color && TF_DATA_DIR=/tmp/tf-ci terraform -chdir=terraform/ci init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-ci terraform -chdir=terraform/ci validate -no-color && TF_DATA_DIR=/tmp/tf-mod terraform -chdir=terraform/modules/metrics init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-mod terraform -chdir=terraform/modules/metrics validate -no-color"]
+    command: ["TF_DATA_DIR=/tmp/tf-root terraform -chdir=terraform init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-root terraform -chdir=terraform validate -no-color && TF_DATA_DIR=/tmp/tf-ci terraform -chdir=terraform/ci init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-ci terraform -chdir=terraform/ci validate -no-color && TF_DATA_DIR=/tmp/tf-mod terraform -chdir=terraform/modules/metrics init -backend=false -input=false -lockfile=readonly && TF_DATA_DIR=/tmp/tf-mod terraform -chdir=terraform/modules/metrics validate -no-color"]
 
   terraform-lint:
-    # checks-terraform lint job: tflint --init, then recursive on terraform/ + a
-    # plain run on terraform/ci, both with the root .tflint.hcl config.
+    # checks-terraform lint job: tflint --init (at the repo root, where
+    # .tflint.hcl auto-loads), then recursive on terraform/ + a plain run on
+    # terraform/ci, both with the root .tflint.hcl config. The image ENTRYPOINT
+    # is tflint, so sh -c runs it from PATH; init writes its plugin cache under
+    # $HOME (container FS), never into the read-only repo mount.
     image: ghcr.io/terraform-linters/tflint:latest
+    entrypoint: ["/bin/sh", "-c"]
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["sh", "-c", "cd terraform && tflint --init && tflint --recursive --format compact --config /repo/.tflint.hcl && cd ci && tflint --format compact --config /repo/.tflint.hcl"]
+    command: ["tflint --init && cd terraform && tflint --recursive --format compact --config /repo/.tflint.hcl && cd ci && tflint --format compact --config /repo/.tflint.hcl"]
 
   terraform-security:
     # checks-terraform security job: checkov-action@v12 (image 3.3.15) with
-    # quiet + soft_fail (informational until the audit backlog lands).
+    # quiet + soft_fail (informational until the audit backlog lands). The
+    # image ENTRYPOINT /entrypoint.sh already execs `checkov "$@"` — args only,
+    # no leading tool name.
     image: ghcr.io/bridgecrewio/checkov:3.3.15
     working_dir: /repo
     volumes:
       - .:/repo:ro
-    command: ["checkov", "-d", "terraform", "--framework", "terraform", "--quiet", "--soft-fail"]
+    command: ["-d", "terraform", "--framework", "terraform", "--quiet", "--soft-fail"]

--- a/scripts/check_local.sh
+++ b/scripts/check_local.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env sh
+# One entry point for the local (stage-1) checks — a thin driver over the
+# check-compose.yaml services. Default: run every surface whose files changed
+# (diff-gated, mirroring the CI checks-*.yml skip-model). --full runs all
+# surfaces unconditionally, exactly like check-compose's documented loop.
+#
+# Usage:
+#   scripts/check_local.sh                     # all surfaces, changed files only
+#   scripts/check_local.sh --full              # all surfaces, whole repo
+#   scripts/check_local.sh shell python        # selected surfaces, changed only
+#   scripts/check_local.sh --full shell js     # selected surfaces, whole repo
+#
+# Surface names match the check-compose.yaml services:
+#   shell · python · yaml · yaml-syntax · js · terraform-fmt · terraform-validate
+#   · terraform-lint · terraform-security     (any number, order preserved)
+#
+# Per-file changed-files linting (pre-commit fast path) stays in
+# scripts/check_changed.sh; this script is the CI-parity gate runner.
+
+set -eu
+
+# shellcheck disable=SC1007  # CDPATH= cd is the intentional empty-CD cd idiom
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT"
+
+# --- CLI ---------------------------------------------------------------------
+MODE="diff"   # diff | full
+SURFACES=""
+for arg in "$@"; do
+  case "$arg" in
+    --full) MODE="full" ;;
+    --diff) MODE="diff" ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) SURFACES="$SURFACES $arg" ;;
+  esac
+done
+
+ALL="shell python yaml yaml-syntax js terraform-fmt terraform-validate terraform-lint terraform-security"
+if [ -z "$SURFACES" ]; then
+  SURFACES="$ALL"
+fi
+
+# --- Changed files (diff mode) ----------------------------------------------
+# Whole branch vs origin/main when it exists (PR-shaped), else vs HEAD;
+# plus any staged/unstaged working-tree changes on top.
+changed_files() {
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    git diff --name-only --diff-filter=ACM origin/main...HEAD
+  fi
+  git diff --name-only --diff-filter=ACM
+  git diff --cached --name-only --diff-filter=ACM
+}
+
+if [ "$MODE" = "diff" ]; then
+  CHANGED="$(changed_files | sort -u)"
+fi
+
+# --- Surface → changed-file globs (mirror the CI checks-*.yml filters) ------
+surface_touched() {
+  # $1 = surface name; reads $CHANGED on stdin
+  case "$1" in
+    shell)              grep -qE '\.sh$|(^|/)\.githooks/' || return 1 ;;
+    python)             grep -q '\.py$' || return 1 ;;
+    js)                 grep -q '\.js$' || return 1 ;;
+    yaml|yaml-syntax)   grep -qE '\.ya?ml$' || return 1 ;;
+    terraform-*)        grep -qE '(^|/)terraform/|\.tflint\.hcl$|\.tf$' || return 1 ;;
+  esac
+}
+
+# --- Run ---------------------------------------------------------------------
+run_surface() {
+  svc="$1"
+  if [ "$MODE" = "full" ]; then
+    reason="full"
+  else
+    if ! printf '%s\n' "$CHANGED" | surface_touched "$svc"; then
+      echo "skip: $svc (no matching files changed)"
+      return 0
+    fi
+    reason="changed"
+  fi
+  echo "== $svc ($reason) =="
+  podman-compose -f check-compose.yaml run --rm "$svc"
+}
+
+status=0
+for svc in $SURFACES; do
+  if ! run_surface "$svc"; then
+    echo "FAILED: $svc"
+    status=1
+  fi
+done
+
+if [ "$MODE" = "diff" ] && [ -z "${CHANGED:-}" ]; then
+  echo "(no changed files detected — nothing to check; use --full for a whole-repo pass)"
+fi
+exit "$status"


### PR DESCRIPTION
Closes #51

## What

`check-compose.yaml` (local stage-1 checks) was broken in ways that made the dev gate untrustworthy, and there was no single driver for the local checks. This PR fixes the checks and adds one:

**1. Fix `check-compose.yaml` so every service is runnable and truthful**
- **yaml-syntax + js were silently checking nothing** — docker-compose interpolates `$f` from the host env at parse time (proved: `f=WORKS` leaked into the container), so the `while read` loops got empty filenames and the trailing `echo ok` masked the errors → exit 0 while no file was validated. Fixed with `$$f` escapes + per-file and pipeline-level `|| exit 1` (negative-tested: broken `.yml`/`.js` now fail).
- **python (ruff)** wrote `.ruff_cache/` into the read-only repo mount → `--no-cache`.
- **terraform-lint / terraform-security / terraform-fmt** double-invoked their tools because each image has a tool ENTRYPOINT (`tflint`, checkov's `/entrypoint.sh`, `/bin/terraform`) → entrypoint-aware commands; tflint `--init` moved to the repo root where `.tflint.hcl` lives (mirrors the workflow).
- **terraform images** qualified as `docker.io/hashicorp/terraform:1.15.9` (short names don't resolve under rootless podman).
- **yaml (actionlint)** — ghcr.io pull returned HTTP 403 on this box → `docker.io/rhysd/actionlint:latest`.

**2. Add `scripts/check_local.sh` — one entry point for the local checks**
- Default: **all surfaces, changed-files only** (diff-gated, mirroring the CI `checks-*.yml` skip-model + `paths-filter` globs).
- `--full`: all surfaces, whole repo (identical to the check-compose loop).
- Per-surface selection: `scripts/check_local.sh shell python`, `scripts/check_local.sh --full shell js`, etc.
- Thin driver over `check-compose.yaml` services — commands/images stay single-sourced.

**3. Docs in sync** — `README.md`, `.github/workflows/README.md`, and the `check-compose.yaml` header now point at `check_local.sh`.

## Verification
- All 9 services exit 0 (`scripts/check_local.sh --full`).
- Negative tests: a broken `.yml` and a broken `.js` both fail their services (no more masked false-greens).
- Diff-gating simulated live: on a branch touching only `check-compose.yaml`, only `yaml` + `yaml-syntax` ran; all other surfaces printed `skip:` with reasons.
- `scripts/check_local.sh` is shellcheck-clean.
- GitHub workflows need no change — CI's `run:` shell is `bash -e -o pipefail`, which already fails fast; the masking was local-only (`sh -c` without `-e`).

## Checklist
- [x] Type of change: fix (`ci`)
- [x] Local checks (stage 1) pass: `scripts/check_local.sh --full`
- [x] Docs updated in sync
- [ ] Reviewed + approved (kizingainc)
