### PR TITLE
docs: backfill CHANGELOG Unreleased to par with v3.2.0..main (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,26 @@ starts immediately after.
 ## [Unreleased]
 
 ### Added
-- **New "The Platform Behind This Site" project page** — `portfolio-platform` as the first entry under Projects; documents the platform (architecture, delivery model, CI/CD, governance, security, incidents) with GitHub references. English first (es/zh follow).
+- **"The Platform Behind This Site" project page** — first entry under Projects (en/es/zh): prose-first case study of the platform (architecture, delivery model, CI/CD, governance, security, real incidents) with GitHub references (#49).
+- **Site Atlas — Platform Architecture page** — the four explored diagrams on-site (site delivery, visitor metrics, Terraform control plane, how a change ships), separate from the zoomable Site Structure map (#50, folded into #53).
+- **Structure-map rectification** — Site Metrics submenu shows its real shape (default → Visitor Analytics → CloudFront → API → writer/reader → DynamoDB); the AWS metrics backend renders inside its own theme-aware subgraph; Projects gains the new page's node (#49/#50/#53).
+- **Release timeline generated from CHANGELOG** — `scripts/releases_hook.py` builds the rows at compile time (no drift); on `v*` tag builds the hook promotes the `[Unreleased]` content into the tag's version so prod shows the just-released release; the Site Atlas landing lists the latest 10, the full archive stays reachable (#49/#50/#53).
+- **Branch + tag rulesets as code** — `main` (PR-only, strict, no bypass) and `v*` tag rulesets defined in exportable JSON and applied via `gh api`; enforcement verified and recorded beside the configs (#25/#35, #36/#38, #37/#39, #40/#41).
+- **Curated labels + template taxonomy** — five per-surface labels (`ci` · `infra` · `security` · `governance` · `dependencies`), PR template ↔ label mapping, 7-part issue structure documented (#11, #15, #18, #26/#27).
+
+### Changed
+- **Docs split into system + implementation views** — root README slimmed to the system view; `.github/workflows/README.md` is the CI/CD implementation reference; `terraform/README.md` audited for accuracy (#23/#28, #24/#34).
+- **Check names are the gate names** — CI reports job names (`ci-build`, `checks-<surface>-<tool>`) so rulesets require exactly what runs; per-surface checks self-gate on changed paths (skip-model), skipping and reporting success when untouched (#12, #17).
+- **Prod deploy split** — `v*` deploys to pre-prod (AWS mirror) then gated prod (GitHub Pages via the official Pages actions); OIDC trust extended for environment-bearing deploy jobs (#20, #22).
+- **Staging content-hash skip** — byte-identical artifacts skip sync + invalidation via marker objects (existence-checked — no extra IAM needed) (#29/#30, #31/#32).
+- **Local check driver** — `scripts/check_local.sh`: default runs every surface whose files changed (diff-gated, mirroring CI), `--full` for a whole-repo pass, per-language selection; `check-compose.yaml` services fixed so every local check is runnable and truthful (#52).
+
+### Fixed
+- **Local checks were silently checking nothing** — docker-compose interpolated `$f` at parse time (empty filenames) and the trailing `echo ok` masked failures; escaped with `$$f` and made per-file failures fail the service (#52).
+- **Broken CJK heading anchor** — zh project page's in-page link pointed at a slug the theme never generated; pinned an explicit `{#delivery-model}` anchor across locales (#49/#50/#53).
+
+### Dependencies
+- Bumps: ruff-action v3, mkdocs-git-revision-date-localized-plugin 1.5.4 (#9, #10).
 
 ## [3.2.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ snapshots (tagged source + site.zip + SBOM); the live site updates on every
 push regardless. Version bumps: minor (`x.y.0`) for features, patch (`x.y.z`)
 for fixes only, major for breaking changes.
 
-**Unreleased section:** the changelog always carries an `## [Unreleased]`
-section at the top once meaningful changes are introduced via issues/PRs; it is
-folded into the version entry at release time and a fresh `## [Unreleased]`
-starts immediately after.
+**Unreleased section:** meaningful changes land under `## [Unreleased]` as they
+are introduced via issues/PRs (a new section is opened by the first change of a
+cycle). A release **renames** that section to its version (`## [X.Y.Z] - date`)
+and adds no empty successor — the next cycle's `## [Unreleased]` is opened by
+its first landed change.
 
 ## [Unreleased]
 


### PR DESCRIPTION
Closes #54

## What

`## [Unreleased]` had drifted to one entry while `v3.2.0..main` held 26 commits of shipped work. Backfilled to par and the cycle policy corrected:

**1. Unreleased backfilled to `v3.2.0..main`** (grouped Added / Changed / Fixed / Dependencies, PR-referenced, sourced from squash-merge subjects):
- **Added** — platform project page; atlas Platform Architecture page; structure-map rectification (Visitor Analytics node + AWS metrics-stack subgraph); CHANGELOG-driven release timeline with tag promotion; branch + tag rulesets as code; curated labels/templates.
- **Changed** — docs split into system/implementation views; check names = job names + skip-model; prod deploy split + OIDC env trust; staging content-hash skip; local check driver.
- **Fixed** — local checks silently checking nothing; broken CJK heading anchor.
- **Dependencies** — ruff-action v3, mkdocs-git-revision-date 1.5.4.

**2. Unreleased-cycle policy corrected** (CHANGELOG header):
- A release **renames** `## [Unreleased]` → `## [X.Y.Z] - date` and adds **no empty successor**.
- The next cycle's `## [Unreleased]` is opened by its **first landed change**, not pre-created at release time.

## Verification
- CHANGELOG-only change — no site/infra/checks impact (`checks-shell/python/js/yml` skip on paths; `ci-build` runs the docs build which is unaffected).
- Content cross-checked against `git log v3.2.0..main` (26 commits) — nothing invented, nothing notable omitted.

## Checklist
- [x] Type of change: docs (`documentation`)
- [x] CHANGELOG policy text matches the working model (release = rename; Unreleased opens on next change)
- [ ] Reviewed + approved (kizingainc)
