### PR TITLE
docs: release v3.3.0 — promote Unreleased to versioned section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ cycle). A release **renames** that section to its version (`## [X.Y.Z] - date`)
 and adds no empty successor — the next cycle's `## [Unreleased]` is opened by
 its first landed change.
 
-## [Unreleased]
+## [3.3.0] - 2026-09-04
 
 ### Added
 - **"The Platform Behind This Site" project page** — first entry under Projects (en/es/zh): prose-first case study of the platform (architecture, delivery model, CI/CD, governance, security, real incidents) with GitHub references (#49).


### PR DESCRIPTION
## Release prep — v3.3.0

Renames `## [Unreleased]` → `## [3.3.0] - 2026-09-04` per the release model (rename only — no empty Unreleased successor; the next cycle opens it with its first landed change).

The section content is the backfilled batch already merged in #55 (platform project page, atlas architecture, structure-map rectification, CHANGELOG-driven release timeline, rulesets, CI overhaul, local checks, deps). This commit is the tag-point: once merged and CI is green on main, tag `v3.3.0` at main tip → pre-prod mirror → gated prod Pages.

CHANGELOG-only change.
